### PR TITLE
fix ansible role for fluent

### DIFF
--- a/operation/roles/fluentbit/tasks/deploy.yml
+++ b/operation/roles/fluentbit/tasks/deploy.yml
@@ -18,14 +18,6 @@
     - "fluent-bit-service-account.yaml"
     - "fluent-bit-service.yaml"
     - "fluent-bit-ds.yaml"
-    namespace: "{{ default_kubernetes_namespace }}"
-  loop:
-  - "{{ remote_manifests_directory }}/fluentbit/fluent-bit-configmap.yaml"
-  - "{{ remote_manifests_directory }}/fluentbit/fluent-bit-role-binding.yaml"
-  - "{{ remote_manifests_directory }}/fluentbit/fluent-bit-role.yaml"
-  - "{{ remote_manifests_directory }}/fluentbit/fluent-bit-service-account.yaml"
-  - "{{ remote_manifests_directory }}/fluentbit/fluent-bit-service.yaml"
-  - "{{ remote_manifests_directory }}/fluentbit/fluent-bit-ds.yaml"
 
 - name: Deploy service monitor for Fluentbit
   k8s:


### PR DESCRIPTION
## Goal 

fix Deploy Fluentbit tasks

Error commit: https://github.com/scalar-labs/scalar-k8s/pull/17/commits/a22f0fa7a7020697da665ff27f8b3ba4aa3bec91

```
- name: Deploy Fluentbit
  k8s:
    state: present
    src: "{{ remote_manifests_directory }}/fluentbit/{{ item }}"
    namespace: "{{ default_kubernetes_namespace }}"
  loop:
    - "fluent-bit-configmap.yaml"
    - "fluent-bit-role-binding.yaml"
    - "fluent-bit-role.yaml"
    - "fluent-bit-service-account.yaml"
    - "fluent-bit-service.yaml"
    - "fluent-bit-ds.yaml"
```
Ci pass Ok: https://github.com/scalar-labs/scalar-k8s/pull/25/checks?check_run_id=809677192

## Reference

https://scalar-labs.atlassian.net/browse/DLT-6494