### PR TITLE
fix ledger resource

### DIFF
--- a/operation/manifests/ledger/scalar-ledger-deployment.yaml
+++ b/operation/manifests/ledger/scalar-ledger-deployment.yaml
@@ -55,10 +55,10 @@ spec:
         resources:
           requests:
             cpu: 1000m
-            memory: 512Mi
+            memory: 2Gi
           limits:
             cpu: 1500m
-            memory: 1024Mi
+            memory: 3Gi
       imagePullSecrets:
       - name: reg-docker-secrets
       restartPolicy: Always


### PR DESCRIPTION
## Goal

following the test with 24 kelpie client we got ~2 Gb of ram on the ledger

![image](https://user-images.githubusercontent.com/2418803/86993344-bc0b9e80-c1de-11ea-9139-5dacd9f19506.png)


## Reference

https://scalar-labs.atlassian.net/browse/DLT-6652