### PR TITLE
Fix helm charts and ci

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Fetch history for chart testing
+        run: git fetch --prune --unshallow
+
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@v1.0.0-rc.2

--- a/charts/stable/scalar-envoy/README.md
+++ b/charts/stable/scalar-envoy/README.md
@@ -27,8 +27,8 @@ Current chart version is `1.0.0`
 | service.ports.envoy.port | int | `50051` | envoy public port |
 | service.ports.envoy.protocol | string | `"TCP"` | envoy protocol |
 | service.ports.envoy.targetPort | int | `50051` | envoy k8s internal name |
-| service.type | string | `"LoadBalancer"` | service types in kubernetes |
-| serviceMonitor.enabled | bool | `true` | enable metrics collect with prometheus |
+| service.type | string | `"ClusterIP"` | service types in kubernetes |
+| serviceMonitor.enabled | bool | `false` | enable metrics collect with prometheus |
 | serviceMonitor.interval | string | `"15s"` | custom interval to retrieve the metrics |
 | serviceMonitor.namespace | string | `"monitoring"` | which namespace prometheus is located. by default monitoring |
 | strategy.rollingUpdate | object | `{"maxSurge":0,"maxUnavailable":1}` | The number of pods that can be unavailable during the update process |

--- a/charts/stable/scalar-envoy/values.yaml
+++ b/charts/stable/scalar-envoy/values.yaml
@@ -49,7 +49,7 @@ securityContext: {}
   # runAsUser: 1000
 service:
   # service.type -- service types in kubernetes
-  type: LoadBalancer
+  type: ClusterIP
   # service.annotations -- Service annotations, e.g: prometheus, etc.
   annotations: {}
   ports:
@@ -70,7 +70,7 @@ service:
 
 serviceMonitor:
   # serviceMonitor.enabled -- enable metrics collect with prometheus
-  enabled: true
+  enabled: false
   # serviceMonitor.interval -- custom interval to retrieve the metrics
   interval: "15s"
   # serviceMonitor.namespace -- which namespace prometheus is located. by default monitoring

--- a/charts/stable/scalar-ledger/templates/batchjob.yaml
+++ b/charts/stable/scalar-ledger/templates/batchjob.yaml
@@ -26,8 +26,6 @@ spec:
         env:
         - name: SCALAR_DB_CONTACT_POINTS
           value: "{{ .Values.scalarLedgerConfiguration.cassandraHost }}"
-        - name: SCALAR_DB_CONTACT_POINTS
-          value: "{{ .Values.scalarLedgerConfiguration.cassandraHost }}"
         - name: SCALAR_DB_CONTACT_PORT
           value: "{{ .Values.scalarLedgerConfiguration.cassandraPort }}"
         - name: SCALAR_DB_USERNAME

--- a/operation/config/envoy-custom-values.yaml
+++ b/operation/config/envoy-custom-values.yaml
@@ -3,6 +3,12 @@ replicaCount: 3
 envoyConfiguration:
   scalardlAddress: sl-scalar-ledger-headless
 
+serviceMonitor:
+  enabled: true
+
+service:
+  type: LoadBalancer
+
 tolerations:
 - effect: NoSchedule
   key: kubernetes.io/app


### PR DESCRIPTION
## Goal

Fix helm charts and fix run helm charts ci:
- LoadBalancer cannot run in kind cluster -> default changed to ClusterIP for testing and LoadBalancer in operation
- cannot test serviceMonitor as no Prometheus in cluster -> disabled in default chart values and activated in operation
- fix double env in scalardl
- add "Fetch history for chart testing" in github actions to avoid error 128 for CT lint see https://github.com/helm/chart-testing-action/issues/25

## Reference

https://scalar-labs.atlassian.net/browse/DLT-6808