### PR TITLE
add inventory_ini to kubernetes output and remove from network

### DIFF
--- a/docs/PrepareBastionTool.md
+++ b/docs/PrepareBastionTool.md
@@ -13,7 +13,7 @@ $ export SCALAR_K8S_HOME=/path/to/local-repository
 # Please update `/path/to/local-repository-config-dir` before running the command.
 $ export SCALAR_K8S_CONFIG_DIR=/path/to/local-repository-config-dir
 
-$ cd ${SCALAR_K8S_HOME}/examples/azure/network
+$ cd ${SCALAR_K8S_HOME}/examples/azure/kubernetes/
 $ terraform output inventory_ini > ${SCALAR_K8S_CONFIG_DIR}/inventory.ini
 ```
 

--- a/docs/ScalarDLonAzureAKS.md
+++ b/docs/ScalarDLonAzureAKS.md
@@ -111,7 +111,7 @@ $ export SCALAR_K8S_CONFIG_DIR=/path/to/local-repository-config-dir
 
 ```
 # Create inventory for ansible
-$ cd ${SCALAR_K8S_HOME}/examples/azure/network
+$ cd ${SCALAR_K8S_HOME}/examples/azure/kubernetes/
 $ terraform output inventory_ini > ${SCALAR_K8S_CONFIG_DIR}/inventory.ini
 
 # Retrieve kube_config for setup kubectl
@@ -183,16 +183,6 @@ bastion_provision_id = 2467232388962733384
 dns_zone_id = internal.scalar-labs.com
 image_id = CentOS
 internal_domain = internal.scalar-labs.com
-inventory_ini = [bastion]
-bastion-example-k8s-azure-b8ci1si.eastus.cloudapp.azure.com
-
-[bastion:vars]
-ansible_user=centos
-ansible_python_interpreter=/usr/bin/python3
-
-[all:vars]
-internal_domain=internal.scalar-labs.com
-
 location = East US
 network_cidr = 10.42.0.0/16
 network_id = /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/example-k8s-azure-fpjzfyk/providers/Microsoft.Network/virtualNetworks/example-k8s-azure-fpjzfyk

--- a/examples/azure/kubernetes/output.tf
+++ b/examples/azure/kubernetes/output.tf
@@ -7,3 +7,17 @@ output "k8s_ssh_config" {
   value       = module.kubernetes.k8s_ssh_config
   description = "The configuration file for K8s API local port forward and SSH K8s Nodes access."
 }
+
+output "inventory_ini" {
+  value = <<EOF
+[bastion]
+${local.network.bastion_ip}
+
+[bastion:vars]
+ansible_user=${local.network.user_name}
+ansible_python_interpreter=/usr/bin/python3
+
+[all:vars]
+internal_domain=${local.network.internal_domain}
+EOF
+}

--- a/examples/azure/network/output.tf
+++ b/examples/azure/network/output.tf
@@ -53,17 +53,3 @@ output "ssh_config" {
 output "internal_domain" {
   value = module.network.internal_domain
 }
-
-output "inventory_ini" {
-  value = <<EOF
-[bastion]
-${module.network.bastion_ip}
-
-[bastion:vars]
-ansible_user=${module.network.user_name}
-ansible_python_interpreter=/usr/bin/python3
-
-[all:vars]
-internal_domain=${module.network.dns_zone_id}
-EOF
-}


### PR DESCRIPTION
# Goal

inventory_ini output is for Kubernetes, not network module. it will easy the move to `scalar-terraform`

## Tasks

- [x] remove `inventory` from network modules output
- [x] add `inventory` to kubernetes output
- [x] update docs

## Reference

https://scalar-labs.atlassian.net/browse/DLT-6969