### PR TITLE
Remove description of tfenv

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -8,7 +8,6 @@ This document refers to the necessary tool to install in your local machine, and
 |:------|:-------|:----------|:------|
 | Ansible | 2.9 | yes | https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html |
 | Terraform | 0.12.x | yes | https://learn.hashicorp.com/terraform/getting-started/install |
-| tfenv | latest | no | https://github.com/tfutils/tfenv |
 | Docker | latest | yes | https://docs.docker.com/install/ |
 | Azure CLI | latest | yes | https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest |
 | Kubectl | 1.16.13 | yes | https://kubernetes.io/docs/tasks/tools/install-kubectl/ |


### PR DESCRIPTION
# Description

- The required version of tfenv is wrong. (1.x or 2.x)
https://github.com/tfutils/tfenv/releases
- `tfenv` is not mandatory. We can use `brew install`
