### PR TITLE
Correct the directory name of tf files in the doc

### DIFF
--- a/docs/ScalarDLonAzureAKS.md
+++ b/docs/ScalarDLonAzureAKS.md
@@ -41,7 +41,7 @@ az login
 
 ### Create network resources
 
-```
+```console
 # Please update `/path/to/local-repository` before running the command.
 $ export SCALAR_K8S_HOME=/path/to/local-repository
 $ cd ${SCALAR_K8S_HOME}/modules/azure/network
@@ -64,7 +64,7 @@ Note that the current version uses [the network module](https://github.com/scala
 
 ### Create Cassandra resources
 
-```
+```console
 $ cd ${SCALAR_K8S_HOME}/modules/azure/cassandra
 
 # Create the cassandra cluster
@@ -76,7 +76,7 @@ Note that the current version uses [the cassandra module](https://github.com/sca
 
 ### Create Kubernetes cluster
 
-```
+```console
 $ cd ${SCALAR_K8S_HOME}/modules/azure/kubernetes
 
 # Create the Kubernetes cluster
@@ -90,7 +90,7 @@ For more information about the variable in `example.tfvars`, please refer to [ku
 
 The Scalar deployment tools include a Prometheus metrics server, Grafana data visualization server, and Alertmanager server for cassandra cluster, cassy, and bastion server
 
-```
+```console
 $ cd ${SCALAR_K8S_HOME}/modules/azure/monitor
 
 # Create the monitor server for cassandra modules and log collection
@@ -105,7 +105,7 @@ Note that the current version uses [the monitor module](https://github.com/scala
 Please decide which directory you want to use to store configuration files for accessing the k8s cluster.
 It is recommended to be set outside of the repo since it should be separately managed per project.
 
-```
+```console
 # Please update `/path/to/local-repository-config-dir` before running the command.
 $ export SCALAR_K8S_CONFIG_DIR=/path/to/local-repository-config-dir
 ```
@@ -118,7 +118,7 @@ $ cp ${SCALAR_K8S_HOME}/conf/{scalardl-custom-values.yaml,schema-loading-custom-
 
 ### Setup bastion for accessing Kubernetes cluster
 
-```
+```console
 # Create inventory for ansible
 $ cd ${SCALAR_K8S_HOME}/modules/azure/kubernetes/
 $ terraform output inventory_ini > ${SCALAR_K8S_CONFIG_DIR}/inventory.ini
@@ -139,7 +139,7 @@ Please refer to [How to install Kubernetes CLI and Helm on the bastion](./Prepar
 
 How to deploy Prometheus metrics server, Grafana data visualization server, and Alertmanager server for Kubernetes resource only. Normally, accessing the Grafana server is enough to see the overall system status.
 
-```
+```console
 $ cd ${SCALAR_K8S_HOME}
 
 # Deploy prometheus operator in Kubernetes
@@ -150,7 +150,7 @@ Please refer to [Kubernetes Monitor Guide](./KubernetesMonitorGuide.md) for more
 
 ### Deploy log collection for Kubernetes resources
 
-```
+```console
 $ cd ${SCALAR_K8S_HOME}
 
 # Deploy fluentbit to collect log from Kubernetes
@@ -168,7 +168,7 @@ You also need set `DOCKERHUB_USER` and `DOCKERHUB_ACCESS_TOKEN` as environment v
 If you use a different internal domain name from the default `internal.scalar-labs.com`, please follow [the extra step](./DeployScalarDL.md#use-a-different-internal-domain) before applying the playbook below.
 
 
-```
+```console
 $ cd ${SCALAR_K8S_HOME}
 
 # export docker secrets for ansible
@@ -237,7 +237,7 @@ cassandra_start_on_initial_boot = false
 
 ### How to access instances
 
-```
+```console
 $ cd ${SCALAR_K8S_HOME}/modules/azure/network
 
 # Generate SSH config to make it easy to access backend resources


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7157

This PR updates the doc to fit the the actual names of the directories where *.tf files exist, which deploy resources with scalar-terraform modules (such as network, cassandra, kubernetes, etc.).
