### PR TITLE
Fix scalardl custom vars for terratest

### DIFF
--- a/test/modules/conf/scalardl-custom-values.yaml
+++ b/test/modules/conf/scalardl-custom-values.yaml
@@ -57,12 +57,6 @@ ledger:
   scalarLedgerConfiguration:
     dbContactPoints: cassandra-lb.internal.scalar-labs.com
 
-    # dbContactPoints: <Cosmos DB account endpoint>
-    # dbContactPort: null
-    # dbUsername: ""
-    # dbPassword: <Cosmos DB account primary master key>
-    # dbStorage: cosmos
-
   prometheusRule:
     enabled: true
 


### PR DESCRIPTION
# Description
https://github.com/scalar-labs/scalar-k8s/runs/1235706189?check_suite_focus=true
```
2020-10-10T15:46:41.1440894Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:41Z ssh.go:414: Running command kubectl get services prod-scalardl-envoy --output jsonpath='{.status.loadBalancer.ingress[0].ip}' on centos@bastion-1-terratest-k8s-37cc2mq.westus.cloudapp.azure.com
2020-10-10T15:46:42.0716792Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:42Z integration_scalardl_test.go:103: URL: 40.125.57.99
2020-10-10T15:46:42.0719325Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:42Z integration_scalardl_test.go:38: URL: 40.125.57.99
2020-10-10T15:46:42.0722554Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:42Z grpc_helper.go:73: Starting Java register-cert [--properties ./resources/test.properties]
2020-10-10T15:46:47.2985839Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:47Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:47.2991375Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:47Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:47.2994867Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:47Z grpc_helper.go:73: Starting Java register-contract [--properties ./resources/test.properties --contract-id test-contract1 --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./resources/StateUpdater.class]
2020-10-10T15:46:49.6574537Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:49Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:49.6577545Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:49Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:49.6580951Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:49Z grpc_helper.go:73: Starting Java execute-contract [--properties ./resources/test.properties --contract-id test-contract1 --contract-argument {"asset_id": "over9000", "state": 9001}]
2020-10-10T15:46:51.3927334Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:51Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:51.3930252Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:51Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:51.3933499Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:51Z grpc_helper.go:73: Starting Java validate-ledger [--properties ./resources/test.properties --asset-id over9000]
2020-10-10T15:46:53.1040155Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:53Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:53.1043320Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:53Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:53.1046681Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:53Z grpc_helper.go:73: Starting Java list-contracts [--properties ./resources/test.properties]
2020-10-10T15:46:54.9575313Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:54Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:54.9578535Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:54Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:54.9581339Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithGrpcWebClient 2020-10-10T15:46:54Z retry.go:69: Running terraform [output -no-color bastion_ip]
```

```
[centos@bastion-1 ~]$ kubectl get pods
NAME                                    READY   STATUS             RESTARTS   AGE
load-schema-schema-loading-khfmc        0/1     Completed          0          38m
prod-scalardl-envoy-568f9cbff9-4f4rm    1/1     Running            0          37m
prod-scalardl-envoy-568f9cbff9-btjlf    1/1     Running            0          37m
prod-scalardl-envoy-568f9cbff9-c8bm7    1/1     Running            0          37m
prod-scalardl-ledger-7479d894d9-8dw8l   0/1     CrashLoopBackOff   12         37m
prod-scalardl-ledger-7479d894d9-8zxxr   0/1     CrashLoopBackOff   12         37m
prod-scalardl-ledger-7479d894d9-vdhsc   0/1     CrashLoopBackOff   12         37m
```

# Done
Fix scalardl custom vars for terratest.

# Confirm
```
[centos@bastion-1 ~]$ helm upgrade --install prod helm/charts/stable/scalardl --namespace default -f helm/charts/config/scalardl-custom-values.yam
l
Release "prod" has been upgraded. Happy Helming!
NAME: prod
LAST DEPLOYED: Mon Oct 12 01:53:26 2020
NAMESPACE: default
STATUS: deployed
REVISION: 3
TEST SUITE: None

[centos@bastion-1 ~]$ kubectl get pods
NAME                                   READY   STATUS      RESTARTS   AGE
load-schema-schema-loading-khfmc       0/1     Completed   0          63m
prod-scalardl-envoy-568f9cbff9-4f4rm   1/1     Running     0          62m
prod-scalardl-envoy-568f9cbff9-btjlf   1/1     Running     0          62m
prod-scalardl-envoy-568f9cbff9-c8bm7   1/1     Running     0          62m
prod-scalardl-ledger-79848fd67-ch4t2   1/1     Running     0          59s
prod-scalardl-ledger-79848fd67-rbxgt   1/1     Running     0          3m16s
prod-scalardl-ledger-79848fd67-twhnh   1/1     Running     0          5m29s
```