### PR TITLE
Fix to use version 2.0.9 for client sdk in terratest

### DIFF
--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -40,7 +40,7 @@ jobs:
           curl -L https://github.com/scalar-labs/scalardl-java-client-sdk/archive/v${SCALARDL_JAVA_CLIENT_SDK_VERSION}.tar.gz | tar xvzf -
           mv ./scalardl-java-client-sdk-${SCALARDL_JAVA_CLIENT_SDK_VERSION} ./scalardl-java-client-sdk
         env:
-          SCALARDL_JAVA_CLIENT_SDK_VERSION: 2.0.3
+          SCALARDL_JAVA_CLIENT_SDK_VERSION: 2.0.9
         working-directory: ./test/src/integration
 
       - name: Set up GO


### PR DESCRIPTION
# Description
Failed in `validate-ledger`
https://github.com/scalar-labs/scalar-k8s/runs/1235706189?check_suite_focus=true
```
2020-10-10T15:46:41.1440894Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:41Z ssh.go:414: Running command kubectl get services prod-scalardl-envoy --output jsonpath='{.status.loadBalancer.ingress[0].ip}' on centos@bastion-1-terratest-k8s-37cc2mq.westus.cloudapp.azure.com
2020-10-10T15:46:42.0716792Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:42Z integration_scalardl_test.go:103: URL: 40.125.57.99
2020-10-10T15:46:42.0719325Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:42Z integration_scalardl_test.go:38: URL: 40.125.57.99
2020-10-10T15:46:42.0722554Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:42Z grpc_helper.go:73: Starting Java register-cert [--properties ./resources/test.properties]
2020-10-10T15:46:47.2985839Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:47Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:47.2991375Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:47Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:47.2994867Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:47Z grpc_helper.go:73: Starting Java register-contract [--properties ./resources/test.properties --contract-id test-contract1 --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./resources/StateUpdater.class]
2020-10-10T15:46:49.6574537Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:49Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:49.6577545Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:49Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:49.6580951Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:49Z grpc_helper.go:73: Starting Java execute-contract [--properties ./resources/test.properties --contract-id test-contract1 --contract-argument {"asset_id": "over9000", "state": 9001}]
2020-10-10T15:46:51.3927334Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:51Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:51.3930252Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:51Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:51.3933499Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:51Z grpc_helper.go:73: Starting Java validate-ledger [--properties ./resources/test.properties --asset-id over9000]
2020-10-10T15:46:53.1040155Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:53Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:53.1043320Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:53Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:53.1046681Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:53Z grpc_helper.go:73: Starting Java list-contracts [--properties ./resources/test.properties]
2020-10-10T15:46:54.9575313Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:54Z grpc_helper.go:91: UNKNOWN_TRANSACTION_STATUS
2020-10-10T15:46:54.9578535Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithJavaClient 2020-10-10T15:46:54Z grpc_helper.go:92: UNAVAILABLE: no healthy upstream
2020-10-10T15:46:54.9581339Z TestEndToEnd/TestScalarDL/scalardl/ScalarDLWithGrpcWebClient 2020-10-10T15:46:54Z retry.go:69: Running terraform [output -no-color bastion_ip]
 
```

# Done
Fix to use version 2.0.9 for client sdk.

# Confirm
```
$ ./scalardl-java-client-sdk/client/bin/validate-ledger --properties ./resources/test.properties --asset-id over9000
{
    "status_code": "OK",
    "output": null,
    "error_message": null
}
```