### PR TITLE
Fix kubernetes python package to 11.0

### DIFF
--- a/playbooks/roles/kubectl/defaults/main.yml
+++ b/playbooks/roles/kubectl/defaults/main.yml
@@ -4,4 +4,4 @@ kubectl_version: v1.16.13
 kubectl_path: /usr/local/bin/kubectl
 kubectl_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
 kubectl_url_checksum_sha256: ab861ec3ec347062bd1b87f8d78d15cd1ce251e74c5fe662e434056962d2a2c9
-python_package: ['kubernetes', 'openshift', 'kubernetes-validate']
+python_package: ['kubernetes<12.0', 'openshift', 'kubernetes-validate']


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-7431

Yesterday, Latest version upgraded to `12.0.0`. 
https://github.com/kubernetes-client/python/releases/tag/v12.0.0

It seems `kubernetes` collection `1.1.1` doesn't support `12.0.0` yet.
https://github.com/ansible-collections/community.kubernetes/releases/tag/1.1.1

# Done
Fix to use `11.x.y`.

# Confirm
```
$ ansible-playbook -i ../test/src/integration/inventory.ini ./playbook-install-tools.yml -e "base_local_directory=../test/src/integration"

TASK [Add stable charts repository from helm] ****************************************************************************************************
skipping: [bastion-1-terratest-k8s-6dbx3ug.westus.cloudapp.azure.com]

PLAY RECAP ***************************************************************************************************************************************
bastion-1-terratest-k8s-6dbx3ug.westus.cloudapp.azure.com : ok=15   changed=4    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```
```
[centos@bastion-1 kubernetes]$ pip list |grep kuber
kubernetes          11.0.0
kubernetes-validate 1.18.0
```