### PR TITLE
Fix to use 1.2.0 for schema loader

### DIFF
--- a/charts/stable/schema-loading/Chart.yaml
+++ b/charts/stable/schema-loading/Chart.yaml
@@ -3,7 +3,7 @@ name: schema-loading
 description: Implementation schema loading for scalar-ledger
 type: application
 version: 1.2.0
-appVersion: 1.1.0
+appVersion: 1.2.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg
 keywords:

--- a/charts/stable/schema-loading/values.yaml
+++ b/charts/stable/schema-loading/values.yaml
@@ -22,7 +22,7 @@ schemaLoading:
     # schemaLoading.image.repository -- Docker image
     repository: scalarlabs/scalardl-schema-loader
     # schemaLoading.image.tag -- Docker tag
-    version: 1.1.0
+    version: 1.2.0
     # schemaLoading.image.pullPolicy -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Description

DATABASE_ERROR
https://github.com/scalar-labs/scalar-k8s/runs/1474593932?check_suite_focus=true

ref:
https://github.com/scalar-labs/scalar-terraform/pull/242

# Done
- Fix to use `1.2.0` for schema-loader image.