### PR TITLE
Use secret object for storing database username and password 

### DIFF
--- a/charts/stable/scalardl/README.md
+++ b/charts/stable/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Implementation scalardl.
-Current chart version is `1.1.0`
+Current chart version is `1.2.0`
 
 ## Values
 
@@ -36,9 +36,10 @@ Current chart version is `1.1.0`
 | envoy.tolerations | list | `[]` | Tolerations are applied to pods, and allow (but do not require) the pods to schedule onto nodes with matching taints. |
 | fullnameOverride | string | `""` | String to fully override scalardl.fullname template |
 | ledger.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
+| ledger.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
-| ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
-| ledger.image.version | string | `"2.0.8"` |  |
+| ledger.image.repository | string | `"scalarlabs/scalar-ledger"` | Docker image |
+| ledger.image.version | string | `"2.1.0"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
 | ledger.podSecurityContext | object | `{}` | PodSecurityContext holds pod-level security attributes and common container settings |

--- a/charts/stable/scalardl/README.md.gotmpl
+++ b/charts/stable/scalardl/README.md.gotmpl
@@ -1,6 +1,8 @@
 {{ template "chart.header" . }}
 
 {{ template "chart.description" . }}
-{{ template "chart.versionLine" . }}
+Current chart version is `{{ template "chart.version" . }}`
+
 {{ template "chart.requirementsSection" . }}
+
 {{ template "chart.valuesSection" . }}

--- a/charts/stable/scalardl/templates/ledger/deployment.yaml
+++ b/charts/stable/scalardl/templates/ledger/deployment.yaml
@@ -43,9 +43,23 @@ spec:
           - name: SCALAR_DB_CONTACT_PORT
             value: "{{ .Values.ledger.scalarLedgerConfiguration.dbContactPort }}"
           - name: SCALAR_DB_USERNAME
-            value: "{{ .Values.ledger.scalarLedgerConfiguration.dbUsername }}"
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.ledger.existingSecret }}
+                name: {{ .Values.ledger.existingSecret }}
+              {{- else }}
+                name: {{ include "scalardl.fullname" . }}-ledger
+              {{- end }}
+                key: db-username
           - name: SCALAR_DB_PASSWORD
-            value: "{{ .Values.ledger.scalarLedgerConfiguration.dbPassword }}"
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.ledger.existingSecret }}
+                name: {{ .Values.ledger.existingSecret }}
+              {{- else }}
+                name: {{ include "scalardl.fullname" . }}-ledger
+              {{- end }}
+                key: db-password
           - name: SCALAR_DB_STORAGE
             value: "{{ .Values.ledger.scalarLedgerConfiguration.dbStorage }}"
           - name: SCALAR_DL_LEDGER_LOG_LEVEL

--- a/charts/stable/scalardl/templates/ledger/secret.yaml
+++ b/charts/stable/scalardl/templates/ledger/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.ledger.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "scalardl.fullname" . }}-ledger
+  labels:
+    {{- include "scalardl-ledger.labels" . | nindent 4 }}
+type: Opaque
+data:
+  db-username: {{ .Values.ledger.scalarLedgerConfiguration.dbUsername | b64enc | quote }}
+  db-password: {{ .Values.ledger.scalarLedgerConfiguration.dbPassword | b64enc | quote }}
+{{- end -}}

--- a/charts/stable/scalardl/values.yaml
+++ b/charts/stable/scalardl/values.yaml
@@ -122,7 +122,7 @@ ledger:
   image:
     # ledger.image.repository -- Docker image
     repository: ghcr.io/scalar-labs/scalar-ledger
-    # ledger.image.tag -- Docker tag
+    # ledger.image.version -- Docker tag
     version: 2.1.0
     # ledger.image.pullPolicy -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent

--- a/charts/stable/scalardl/values.yaml
+++ b/charts/stable/scalardl/values.yaml
@@ -184,3 +184,6 @@ ledger:
 
   # ledger.affinity -- the affinity/anti-affinity feature, greatly expands the types of constraints you can express
   affinity: {}
+
+  # ledger.existingSecret -- Name of existing secret to use for storing database username and password
+  existingSecret: null

--- a/charts/stable/schema-loading/README.md
+++ b/charts/stable/schema-loading/README.md
@@ -1,7 +1,7 @@
 # schema-loading
 
 Implementation schema loading for scalar-ledger
-Current chart version is `1.1.0`
+Current chart version is `1.2.0`
 
 ## Values
 
@@ -12,9 +12,10 @@ Current chart version is `1.1.0`
 | schemaLoading.contactPort | int | `9042` | The database port number. (Ignored if the database is `cosmos`.) |
 | schemaLoading.cosmosBaseResourceUnit | int | `400` | The resource unit value of the Cosmos DB schema. This is a Cosmos DB specific option. |
 | schemaLoading.database | string | `"cassandra"` | The database to which the schema is loaded. `cassandra` and `cosmos` are supported. |
+| schemaLoading.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password |
 | schemaLoading.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
 | schemaLoading.image.repository | string | `"ghcr.io/scalar-labs/scalardl-schema-loader"` | Docker image |
-| schemaLoading.image.version | string | `"1.1.0"` |  |
+| schemaLoading.image.version | string | `"1.2.0"` | Docker tag |
 | schemaLoading.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | schemaLoading.password | string | `"cassandra"` | The password of the database. For Cosmos DB, please specify a key here. |
 | schemaLoading.username | string | `"cassandra"` | The username of the database. (Ignored if the database is `cosmos`.) |

--- a/charts/stable/schema-loading/README.md.gotmpl
+++ b/charts/stable/schema-loading/README.md.gotmpl
@@ -1,6 +1,8 @@
 {{ template "chart.header" . }}
 
 {{ template "chart.description" . }}
-{{ template "chart.versionLine" . }}
+Current chart version is `{{ template "chart.version" . }}`
+
 {{ template "chart.requirementsSection" . }}
+
 {{ template "chart.valuesSection" . }}

--- a/charts/stable/schema-loading/templates/batchjob-schema-loading.yaml
+++ b/charts/stable/schema-loading/templates/batchjob-schema-loading.yaml
@@ -24,9 +24,9 @@ spec:
         - "-P"
         - "{{ .Values.schemaLoading.contactPort }}"
         - "-u"
-        - "{{ .Values.schemaLoading.username }}"
+        - "$(DB_USERNAME)"
         - "-p"
-        - "{{ .Values.schemaLoading.password }}"
+        - "$(DB_PASSWORD)"
         {{- if eq .Values.schemaLoading.database "cassandra" }}
         - "--cassandra"
         - "-n"
@@ -38,5 +38,24 @@ spec:
         - "-r"
         - "{{ .Values.schemaLoading.cosmosBaseResourceUnit }}"
         {{- end }}
+        env:
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.schemaLoading.existingSecret }}
+              name: {{ .Values.schemaLoading.existingSecret }}
+            {{- else }}
+              name: {{ include "schema-loading.fullname" . }}
+            {{- end }}
+              key: db-username
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.schemaLoading.existingSecret }}
+              name: {{ .Values.schemaLoading.existingSecret }}
+            {{- else }}
+              name: {{ include "schema-loading.fullname" . }}
+            {{- end }}
+              key: db-password
       restartPolicy: Never
   backoffLimit: 0

--- a/charts/stable/schema-loading/templates/secret.yaml
+++ b/charts/stable/schema-loading/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.schemaLoading.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "schema-loading.fullname" . }}
+  labels:
+    {{- include "schema-loading.labels" . | nindent 4 }}
+type: Opaque
+data:
+  db-username: {{ .Values.schemaLoading.username | b64enc | quote }}
+  db-password: {{ .Values.schemaLoading.password | b64enc | quote }}
+{{- end -}}

--- a/charts/stable/schema-loading/values.yaml
+++ b/charts/stable/schema-loading/values.yaml
@@ -21,7 +21,7 @@ schemaLoading:
   image:
     # schemaLoading.image.repository -- Docker image
     repository: ghcr.io/scalar-labs/scalardl-schema-loader
-    # schemaLoading.image.tag -- Docker tag
+    # schemaLoading.image.version -- Docker tag
     version: 1.2.0
     # schemaLoading.image.pullPolicy -- Specify a imagePullPolicy
     pullPolicy: IfNotPresent

--- a/charts/stable/schema-loading/values.yaml
+++ b/charts/stable/schema-loading/values.yaml
@@ -28,3 +28,6 @@ schemaLoading:
 
   # schemaLoading.imagePullSecrets -- Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   imagePullSecrets: [name: reg-docker-secrets]
+
+  # schemaLoading.existingSecret -- Name of existing secret to use for storing database username and password
+  existingSecret: null


### PR DESCRIPTION
Currently, database username and password are set directly in Deployment
`spec.template.spec.containers.env`, so it can be viewed by users with
any privileges. In general, credentials should only be visible to
administrators. So I change to use Secret objects for storing database
username and password.

Some users may want to use an existing Secret object. They can use
`ledger.existingSecret` to specify the Secret object name to use.