### PR TITLE
Add a script file to update chart docs

### DIFF
--- a/.github/workflows/helm_charts_scalar.yml
+++ b/.github/workflows/helm_charts_scalar.yml
@@ -89,3 +89,10 @@ jobs:
         with:
           command: "install"
           config: .github/ct.yaml
+
+  verify-chart-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Verify chart docs
+        run: ./scripts/verify-chart-docs.sh

--- a/scripts/update-chart-docs.sh
+++ b/scripts/update-chart-docs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This script updates README.md for Helm charts with helm-docs tool.
+#
+# https://github.com/norwoodj/helm-docs
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
+docker run --rm -v "${SCRIPT_ROOT}/..:/helm-docs" -u $(id -u) docker.io/jnorwood/helm-docs
+# vim: ai ts=2 sw=2 et sts=2 ft=sh

--- a/scripts/verify-chart-docs.sh
+++ b/scripts/verify-chart-docs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
+
+docs="${SCRIPT_ROOT}/../charts/stable/**/README.md"
+"${SCRIPT_ROOT}/update-chart-docs.sh"
+
+set +e
+git diff --no-patch --exit-code "$docs"
+exit_code="$?"
+set -e
+
+# Discard changes
+git checkout -- "$docs"
+
+if [[ "$exit_code" != 0 ]]; then
+  echo
+  echo "Run ./scripts/update-chart-docs.sh"
+  exit 1
+fi
+# vim: ai ts=2 sw=2 et sts=2 ft=sh


### PR DESCRIPTION
This commit adds `update-chart-docs.sh` that updates README.md for each
Helm charts and `verify-chart-docs.sh` that checks if README.md needs to
be updated. `verify-chart-docs.sh` can be run in CI to prevent
forgetting to update README.md.

---

This PR is based on #92. Please review and merge it first.