### PR TITLE
Create srv records for scalardl

### DIFF
--- a/charts/stable/scalardl/Chart.yaml
+++ b/charts/stable/scalardl/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalardl
 description: Implementation scalardl.
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.1.0
 deprecated: false
 icon: https://scalar-labs.com/wp-content/themes/scalar/assets/img/logo_scalar.svg

--- a/charts/stable/scalardl/README.md
+++ b/charts/stable/scalardl/README.md
@@ -1,7 +1,7 @@
 # scalardl
 
 Implementation scalardl.
-Current chart version is `1.2.0`
+Current chart version is `1.2.1`
 
 ## Values
 
@@ -38,7 +38,7 @@ Current chart version is `1.2.0`
 | ledger.affinity | object | `{}` | the affinity/anti-affinity feature, greatly expands the types of constraints you can express |
 | ledger.existingSecret | string | `nil` | Name of existing secret to use for storing database username and password |
 | ledger.image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy |
-| ledger.image.repository | string | `"scalarlabs/scalar-ledger"` | Docker image |
+| ledger.image.repository | string | `"ghcr.io/scalar-labs/scalar-ledger"` | Docker image |
 | ledger.image.version | string | `"2.1.0"` | Docker tag |
 | ledger.imagePullSecrets | list | `[{"name":"reg-docker-secrets"}]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. |
 | ledger.nodeSelector | object | `{}` | nodeSelector is form of node selection constraint |
@@ -54,6 +54,16 @@ Current chart version is `1.2.0`
 | ledger.scalarLedgerConfiguration.dbUsername | string | `"cassandra"` | The username of the database |
 | ledger.scalarLedgerConfiguration.ledgerLogLevel | string | `"INFO"` | The log level of Scalar ledger |
 | ledger.securityContext | object | `{}` | Setting security context at the pod applies those settings to all containers in the pod |
+| ledger.service.annotations | object | `{}` |  |
+| ledger.service.ports.scalardl-admin.port | int | `50053` | scalardl-admin target port |
+| ledger.service.ports.scalardl-admin.protocol | string | `"TCP"` | scalardl-admin protocol |
+| ledger.service.ports.scalardl-admin.targetPort | int | `50053` | scalardl-admin k8s internal name |
+| ledger.service.ports.scalardl-priv.port | int | `50052` | scalardl-priv target port |
+| ledger.service.ports.scalardl-priv.protocol | string | `"TCP"` | scalardl-priv protocol |
+| ledger.service.ports.scalardl-priv.targetPort | int | `50052` | scalardl-priv k8s internal name |
+| ledger.service.ports.scalardl.port | int | `50051` | scalardl target port |
+| ledger.service.ports.scalardl.protocol | string | `"TCP"` | scalardl protocol |
+| ledger.service.ports.scalardl.targetPort | int | `50051` | scalardl k8s internal name |
 | ledger.service.type | string | `"ClusterIP"` | service types in kubernetes |
 | ledger.strategy.rollingUpdate | object | `{"maxSurge":0,"maxUnavailable":1}` | The number of pods that can be unavailable during the update process |
 | ledger.strategy.type | string | `"RollingUpdate"` | New pods are added gradually, and old pods are terminated gradually, e.g: Recreate or RollingUpdate |

--- a/charts/stable/scalardl/templates/ledger/service.yaml
+++ b/charts/stable/scalardl/templates/ledger/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "scalardl-ledger.labels" . | nindent 4 }}
   annotations:
-{{ toYaml .Values.ledger.service.annotations | indent 4 }}
+    {{- toYaml .Values.ledger.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.ledger.service.type }}
   clusterIP: None

--- a/charts/stable/scalardl/templates/ledger/service.yaml
+++ b/charts/stable/scalardl/templates/ledger/service.yaml
@@ -4,9 +4,16 @@ metadata:
   name: {{ include "scalardl.fullname" . }}-ledger-headless
   labels:
     {{- include "scalardl-ledger.labels" . | nindent 4 }}
+  annotations:
+{{ toYaml .Values.ledger.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.ledger.service.type }}
   clusterIP: None
   sessionAffinity: None
+  ports:
+  {{- range $key, $value := .Values.ledger.service.ports }}
+    - name: {{ $key }}
+{{ toYaml $value | indent 6 }}
+  {{- end }}
   selector:
     {{- include "scalardl-ledger.selectorLabels" . | nindent 4 }}

--- a/charts/stable/scalardl/values.yaml
+++ b/charts/stable/scalardl/values.yaml
@@ -156,6 +156,29 @@ ledger:
   service:
     # ledger.service.type -- service types in kubernetes
     type: ClusterIP
+    annotations: {}
+    ports:
+      scalardl:
+        # ledger.service.ports.scalardl.port -- scalardl target port
+        port: 50051
+        # ledger.service.ports.scalardl.targetPort -- scalardl k8s internal name
+        targetPort: 50051
+        # ledger.service.ports.scalardl.protocol -- scalardl protocol
+        protocol: TCP
+      scalardl-priv:
+        # ledger.service.ports.scalardl-priv.port -- scalardl-priv target port
+        port: 50052
+        # ledger.service.ports.scalardl-priv.targetPort -- scalardl-priv k8s internal name
+        targetPort: 50052
+        # ledger.service.ports.scalardl-priv.protocol -- scalardl-priv protocol
+        protocol: TCP
+      scalardl-admin:
+        # ledger.service.ports.scalardl-admin.port -- scalardl-admin target port
+        port: 50053
+        # ledger.service.ports.scalardl-admin.targetPort -- scalardl-admin k8s internal name
+        targetPort: 50053
+        # ledger.service.ports.scalardl-admin.protocol -- scalardl-admin protocol
+        protocol: TCP
 
   prometheusRule:
     # ledger.prometheusRule.enabled -- enable rules for prometheus


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-8007

# Done
- Add srv records for ledger

# Confirm
```
[centos@bastion-1 ~]$ kubectl describe svc prod-scalardl-ledger-headless
Name:              prod-scalardl-ledger-headless
Namespace:         default
Labels:            app.kubernetes.io/app=ledger
                   app.kubernetes.io/instance=prod
                   app.kubernetes.io/managed-by=Helm
                   app.kubernetes.io/name=scalardl
                   app.kubernetes.io/version=2.1.0
                   helm.sh/chart=scalardl-1.2.0
Annotations:       meta.helm.sh/release-name: prod
                   meta.helm.sh/release-namespace: default
Selector:          app.kubernetes.io/app=ledger,app.kubernetes.io/instance=prod,app.kubernetes.io/name=scalardl
Type:              ClusterIP
IP:                None
Port:              scalardl  50051/TCP
TargetPort:        50051/TCP
Endpoints:         10.42.40.42:50051,10.42.40.54:50051,10.42.40.66:50051
Port:              scalardl-admin  50053/TCP
TargetPort:        50053/TCP
Endpoints:         10.42.40.42:50053,10.42.40.54:50053,10.42.40.66:50053
Port:              scalardl-priv  50052/TCP
TargetPort:        50052/TCP
Endpoints:         10.42.40.42:50052,10.42.40.54:50052,10.42.40.66:50052
Session Affinity:  None
Events:            <none>

[centos@bastion-1 ~]$ kubectl exec -i -t dnsutils -- nslookup _scalardl._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Server:         10.42.48.2
Address:        10.42.48.2#53

Name:   _scalardl._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.66
Name:   _scalardl._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.42
Name:   _scalardl._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.54

[centos@bastion-1 ~]$ kubectl exec -i -t dnsutils -- nslookup _scalardl-priv._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Server:         10.42.48.2
Address:        10.42.48.2#53

Name:   _scalardl-priv._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.54
Name:   _scalardl-priv._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.66
Name:   _scalardl-priv._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.42

[centos@bastion-1 ~]$ kubectl exec -i -t dnsutils -- nslookup _scalardl-admin._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Server:         10.42.48.2
Address:        10.42.48.2#53

Name:   _scalardl-admin._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.54
Name:   _scalardl-admin._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.42
Name:   _scalardl-admin._tcp.prod-scalardl-ledger-headless.default.svc.cluster.local
Address: 10.42.40.66
```