### PR TITLE
Update document for changing Helm values for CosmosDB Configuration

### DIFF
--- a/conf/scalardl-custom-values.yaml
+++ b/conf/scalardl-custom-values.yaml
@@ -60,8 +60,6 @@ ledger:
     dbContactPoints: cassandra-lb.internal.scalar-labs.com
 
     # dbContactPoints: <Cosmos DB account endpoint>
-    # dbContactPort: null
-    # dbUsername: ""
     # dbPassword: <Cosmos DB account primary master key>
     # dbStorage: cosmos
 

--- a/docs/HelmValuesFiles.md
+++ b/docs/HelmValuesFiles.md
@@ -46,8 +46,8 @@ Finally, open `${SCALAR_K8S_CONFIG_DIR}/scalardl-custom-values.yaml` and uncomme
 ```yaml
   scalarLedgerConfiguration:
     dbContactPoints: https://example-k8s-azure-b8ci1si-cosmosdb.documents.azure.com:443/
-    #dbContactPort: null
-    #dbUsername: ""
+    # dbContactPort: null
+    # dbUsername: ""
     dbPassword: <PRIMARY_MASTER_KEY>
     dbStorage: cosmos
 ```

--- a/docs/HelmValuesFiles.md
+++ b/docs/HelmValuesFiles.md
@@ -46,8 +46,6 @@ Finally, open `${SCALAR_K8S_CONFIG_DIR}/scalardl-custom-values.yaml` and uncomme
 ```yaml
   scalarLedgerConfiguration:
     dbContactPoints: https://example-k8s-azure-b8ci1si-cosmosdb.documents.azure.com:443/
-    # dbContactPort: null
-    # dbUsername: ""
     dbPassword: <PRIMARY_MASTER_KEY>
     dbStorage: cosmos
 ```

--- a/docs/HelmValuesFiles.md
+++ b/docs/HelmValuesFiles.md
@@ -39,19 +39,15 @@ schemaLoading:
   contactPoints: https://example-k8s-azure-b8ci1si-cosmosdb.documents.azure.com:443/
   password: <PRIMARY_MASTER_KEY>
   cosmosBaseResourceUnit: "400"
-  image:
-    repository: ghcr.io/scalar-labs/scalardl-schema-loader
-    version: 1.0.0
-    pullPolicy: IfNotPresent
 ```
 
-Finally, open `${SCALAR_K8S_CONFIG_DIR}/scalardl-custom-values.yaml` and uncomment and update the values of the `scalarLedgerConfiguration`.
+Finally, open `${SCALAR_K8S_CONFIG_DIR}/scalardl-custom-values.yaml` and uncomment `dbContactPoints`, `dbPassword`, `dbStorage` and update the values of the `scalarLedgerConfiguration`.
 
 ```yaml
   scalarLedgerConfiguration:
     dbContactPoints: https://example-k8s-azure-b8ci1si-cosmosdb.documents.azure.com:443/
-    dbContactPort: null
-    dbUsername: ""
+    #dbContactPort: null
+    #dbUsername: ""
     dbPassword: <PRIMARY_MASTER_KEY>
     dbStorage: cosmos
 ```


### PR DESCRIPTION
This PR fixes the following issues in the document 

Schema loading
---------------------
Using the current document after updating the `schema-loading-custom-values.yaml` following error occurs and schema loading not working.
```
ERROR: ["Unknown option: \"-P\""]
      --cassandra                                   Operate for Cassandra
      --cosmos                                      Operate for Cosmos DB
  -h, --host DB_HOST                                Address of Cassandra like IP or URI address of your Cosmos DB account
  -u, --user USERNAME                               Username of the database. This option is ignored when Cosmos DB.
  -p, --password ACCOUNT_PASSWORD                   Password of Cassandra or Cosmos DB account
  -f, --schema-file SCHEMA_JSON                     Schema file
  -r, --ru RESOURCE_UNIT                       400  Base RU for each table on Cosmos DB. The RU of the coordinator for Scalar DB transaction is specified by this option. This option is ignored when Cassandra.
  -R, --replication-factor REPLICATION_FACTOR  1    The number of replicas. This options is ignored when Cosmos DB.
  -n, --network-strategy NETWORK_STRATEGY           The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This options is ignored when Cosmos DB.
  -D, --delete-all                                  All database will be deleted, if this is enabled.
      --help
```

Scalar Ledger
------------------
Also, after updating the `scalardl-custom-values.yaml` file following error occur and ledger pods are in a crashed state

```
2021-02-10 05:58:45,292 [INFO  com.scalar.dl.ledger.config.LedgerConfig] LedgerConfig{scalar.dl.ledger.name=Scalar Ledger, scalar.dl.ledger.isolation=SNAPSHOT, scalar.dl.ledger.server.port=50051, scalar.dl.ledger.server.privileged_port=50052, scalar.dl.ledger.server.admin_port=50053, scalar.dl.ledger.server.tls.enabled=false, scalar.dl.ledger.server.tls.cert_chain_path=null, scalar.dl.ledger.server.tls.private_key_path=null, scalar.dl.ledger.proof.enabled=false, scalar.dl.ledger.proof.private_key_path=null, scalar.dl.ledger.function.enabled=true, scalar.dl.ledger.nonce_txid.enabled=true, scalar.dl.ledger.ordering.enabled=false, scalar.dl.ledger.executable_contracts=[]}
java.lang.NumberFormatException: For input string: ""
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:592)
	at java.lang.Integer.parseInt(Integer.java:615)
	at com.scalar.db.config.DatabaseConfig.load(DatabaseConfig.java:58)
	at com.scalar.db.config.DatabaseConfig.<init>(DatabaseConfig.java:46)
	at com.scalar.dl.ledger.service.LedgerModule.<init>(LedgerModule.java:35)
	at com.scalar.dl.ledger.server.LedgerServerModule.<init>(LedgerServerModule.java:19)
	at com.scalar.dl.ledger.server.LedgerServer.start(LedgerServer.java:39)
	at com.scalar.dl.ledger.server.LedgerServer.call(LedgerServer.java:33)
	at com.scalar.dl.ledger.server.LedgerServer.call(LedgerServer.java:15)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1783)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2141)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at com.scalar.dl.ledger.server.LedgerServer.main(LedgerServer.java:149)
2021/02/10 05:58:45 Command exited with error: exit status 1
```