### PR TITLE
Fix to use default  storage class for ebs

### DIFF
--- a/playbooks/roles/prometheus/defaults/main.yml
+++ b/playbooks/roles/prometheus/defaults/main.yml
@@ -6,11 +6,12 @@ helm_binary_path: /usr/local/bin/helm
 deploy_prometheus: yes
 create_dashboard: yes
 alertmanager_notification_activated: false
-# slack_webhook_url: "https://hooks.slack.com/services/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx" 
+# slack_webhook_url: "https://hooks.slack.com/services/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx"
 prometheus_crds_url:
-- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+storage_class:  "{% if cloud_provider is defined and cloud_provider == 'aws' %} gp2 {% else %} default {% endif %}"

--- a/playbooks/roles/prometheus/defaults/main.yml
+++ b/playbooks/roles/prometheus/defaults/main.yml
@@ -6,12 +6,11 @@ helm_binary_path: /usr/local/bin/helm
 deploy_prometheus: yes
 create_dashboard: yes
 alertmanager_notification_activated: false
-# slack_webhook_url: "https://hooks.slack.com/services/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx"
+# slack_webhook_url: "https://hooks.slack.com/services/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx/xxxxxxxxxxxxxxx" 
 prometheus_crds_url:
-  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-  - https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
-storage_class:  "{% if cloud_provider is defined and cloud_provider == 'aws' %} gp2 {% else %} default {% endif %}"
+- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+- https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml

--- a/playbooks/roles/prometheus/templates/prometheus-custom-values.yaml.j2
+++ b/playbooks/roles/prometheus/templates/prometheus-custom-values.yaml.j2
@@ -63,7 +63,7 @@ alertmanager:
             {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
             {{ end }}
           {{ end }}{% endraw %}
-        
+
         title_link: 'https://github.com/scalar-labs/scalar-kubernetes/tree/master/docs/alerts/{% raw %}{{ .GroupLabels.app }}.md#{{ .GroupLabels.alertname }}{% endraw %}'
 {% endif %}
 
@@ -116,7 +116,7 @@ grafana:
 
   persistence:
     enabled: false
-    storageClassName: default
+    storageClassName: {{ storage_class }}
     accessModes: ["ReadWriteOnce"]
     size: 2Gi
 
@@ -170,7 +170,7 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: default
+          storageClassName: {{ storage_class }}
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:

--- a/playbooks/roles/prometheus/templates/prometheus-custom-values.yaml.j2
+++ b/playbooks/roles/prometheus/templates/prometheus-custom-values.yaml.j2
@@ -116,7 +116,6 @@ grafana:
 
   persistence:
     enabled: false
-    storageClassName: {{ storage_class }}
     accessModes: ["ReadWriteOnce"]
     size: 2Gi
 
@@ -170,7 +169,6 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: {{ storage_class }}
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:


### PR DESCRIPTION
# Description

storageclass.storage.k8s.io "default" not found

```
Events:
  Type     Reason             Age                From                Message
  ----     ------             ----               ----                -------
  Warning  FailedScheduling   53s (x2 over 54s)  default-scheduler   0/6 nodes are available: 6 pod has unbound immediate PersistentVolumeClaims.
  Normal   NotTriggerScaleUp  44s                cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added): 2 running "VolumeBinding" filter plugin for pod "prometheus-prometheus-prometheus-oper-prometheus-0": pod has unbound immediate PersistentVolumeClaims
```

```
[centos@bastion-1 ~]$ kubectl describe pvc prometheus-prometheus-prometheus-oper-prometheus-db-prometheus-prometheus-prometheus-oper-prometheus-0  -n monitoring
Name:          prometheus-prometheus-prometheus-oper-prometheus-db-prometheus-prometheus-prometheus-oper-prometheus-0
Namespace:     monitoring
StorageClass:  default
Status:        Pending
Volume:
Labels:        app=prometheus
               prometheus=prometheus-prometheus-oper-prometheus
Annotations:   <none>
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Mounted By:    prometheus-prometheus-prometheus-oper-prometheus-0
Events:
  Type     Reason              Age                   From                         Message
  ----     ------              ----                  ----                         -------
  Warning  ProvisioningFailed  10s (x14 over 3m17s)  persistentvolume-controller  storageclass.storage.k8s.io "default" not found
```

Default name of `storageclass` is `gp2` in `EKS`
```
[centos@bastion-1 ~]$ kubectl get storageclass
NAME            PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
gp2 (default)   kubernetes.io/aws-ebs   Delete          WaitForFirstConsumer   false                  29m
```

storageclass in `AKS`
```
[centos@bastion-1 ~]$ kubectl get storageclass
NAME                PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
azurefile           kubernetes.io/azure-file   Delete          Immediate              true                   24h
azurefile-premium   kubernetes.io/azure-file   Delete          Immediate              true                   24h
default (default)   kubernetes.io/azure-disk   Delete          WaitForFirstConsumer   true                   24h
managed-premium     kubernetes.io/azure-disk   Delete          WaitForFirstConsumer   true                   24h
```