### PR TITLE
Refactoring kubectl role

### DIFF
--- a/playbooks/roles/kubectl/defaults/main.yml
+++ b/playbooks/roles/kubectl/defaults/main.yml
@@ -1,7 +1,8 @@
 base_local_directory: ../conf
 kubectl_local_config_directory: "{{ base_local_directory }}/kube_config"
-kubectl_version: v1.16.13
+kubectl_version: v1.19.10
 kubectl_path: /usr/local/bin/kubectl
-kubectl_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
-kubectl_url_checksum_sha256: ab861ec3ec347062bd1b87f8d78d15cd1ce251e74c5fe662e434056962d2a2c9
-python_package: ['kubernetes<12.0', 'openshift', 'kubernetes-validate']
+kubectl_binary_path: /usr/local/bin/kubectl-{{ kubectl_version }}
+kubectl_url: "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+kubectl_checksum_sha256: dbacc1a372f00e2d15ad9a39925191c4e314e39b37dcac3e5b2f5e98f4be0d47
+python_package: ['kubernetes', 'openshift', 'kubernetes-validate']

--- a/playbooks/roles/kubectl/tasks/install.yml
+++ b/playbooks/roles/kubectl/tasks/install.yml
@@ -1,11 +1,21 @@
 ---
+- name: Check the installed kubectl
+  stat:
+    path: "{{ kubectl_binary_path }}"
+  changed_when: false
+  register: kubectl_binary_result
+
 - name: Download and install binary on the admin server
   get_url:
     url: "{{ kubectl_url }}"
-    dest: "{{ kubectl_path }}"
-    checksum: "sha256:{{ kubectl_url_checksum_sha256 }}"
-
-- name: Set permissions for kubectl
-  file:
-    path: "{{ kubectl_path }}"
+    dest: "{{ kubectl_binary_path }}"
+    checksum: "sha256:{{ kubectl_checksum_sha256 }}"
     mode: 0755
+  when: not kubectl_binary_result.stat.exists
+
+- name: Create kubectl symlink
+  file:
+    src: "{{ kubectl_binary_path }}"
+    path: "{{ kubectl_path }}"
+    force: yes
+    state: link

--- a/playbooks/roles/kubectl/tasks/setup.yml
+++ b/playbooks/roles/kubectl/tasks/setup.yml
@@ -11,7 +11,7 @@
   copy:
     src: "{{ kubectl_local_config_directory }}"
     dest: "/home/{{ ansible_user }}/.kube/config"
-    mode: 0644
+    mode: 0600
 
 - name: Check if kubectl completion exists on admin server
   stat:


### PR DESCRIPTION
# Description

- Upgrade kubectl to `1.19.10`
- Fix to use symlink
- Fix permission for `~/.kube/config`
  ```
  [centos@bastion-1 ~]$ helm list
  WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/centos/.kube/config
  WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/centos/.kube/config
  ```