### PR TITLE
Delete helm plugin installation in prometheus role

### DIFF
--- a/playbooks/roles/prometheus/tasks/deploy.yml
+++ b/playbooks/roles/prometheus/tasks/deploy.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install Helm Diff
-  kubernetes.core.helm_plugin:
-    state: present
-    plugin_path: https://github.com/databus23/helm-diff
-
 - name: Add prometheus-community chart repo
   kubernetes.core.helm_repository:
     name: prometheus


### PR DESCRIPTION
# Description

The helm plugins are installed by `helm` role, so no longer needed in `prometheus` role.

https://github.com/scalar-labs/scalar-kubernetes/blob/31d00056c39f9fde2a2051d1410958940c92f583/playbooks/roles/helm/tasks/plugins.yml#L24-L30