### PR TITLE
Fix scalardl helm chart version to 1.2.3

### DIFF
--- a/playbooks/playbook-deploy-scalardl.yml
+++ b/playbooks/playbook-deploy-scalardl.yml
@@ -15,7 +15,7 @@
     # scalardl_helm_release_name: prod
     # helm_charts_repo_url: https://scalar-labs.github.io/helm-charts
     # helm_charts_repo_name: scalar-labs
-    # scalardl_chart_version: 1.2.2
+    # scalardl_chart_version: 1.2.3
     # schema_loading_chart_version: 1.3.0
   roles:
     - { role: scalardl, tags: scalardl }

--- a/playbooks/roles/scalardl/defaults/main.yml
+++ b/playbooks/roles/scalardl/defaults/main.yml
@@ -3,7 +3,7 @@ remote_directory: "/home/{{ ansible_user }}"
 helm_charts_custom_config_path: "{{ remote_directory }}/helm/config"
 helm_charts_repo_url: https://scalar-labs.github.io/helm-charts
 helm_charts_repo_name: scalar-labs
-scalardl_chart_version: 1.2.2
+scalardl_chart_version: 1.2.3
 schema_loading_chart_version: 1.3.0
 docker_registry: ghcr.io
 docker_username: "{{ lookup('env','DOCKER_REGISTRY_USERNAME') }}"


### PR DESCRIPTION
# Description
The first version released on github pages is `1.2.3`.
https://github.com/scalar-labs/helm-charts/releases/tag/scalardl-1.2.3