### PR TITLE
Add JDBC support in the azure manual scalar dl  deployment guide 

### DIFF
--- a/docs/ManualDeploymentGuideScalarDLOnAzure.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAzure.md
@@ -12,8 +12,10 @@ In this guide, we will create the following components.
 
 * An Azure Virtual Network associated with a Resource Group.
 * An AKS cluster with a Kubernetes node pool.
-* A managed database service.
+* A managed database service (you can choose one of them).
     * A Cosmos DB Account.
+    * An Azure Database for MySQL servers.
+    * An Azure Database for PostgreSQL servers.
 * A Bastion instance with a public IP.
 * Azure container insights.
 

--- a/docs/ManualDeploymentGuideScalarDLOnAzure.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAzure.md
@@ -14,8 +14,8 @@ In this guide, we will create the following components.
 * An AKS cluster with a Kubernetes node pool.
 * A managed database service (you can choose one of them).
     * A Cosmos DB Account.
-    * An Azure Database for MySQL servers.
-    * An Azure Database for PostgreSQL servers.
+    * An Azure Database for MySQL.
+    * An Azure Database for PostgreSQL.
 * A Bastion instance with a public IP.
 * Azure container insights.
 

--- a/docs/SetupAzureDatabase.md
+++ b/docs/SetupAzureDatabase.md
@@ -55,7 +55,7 @@ By default, the scalardl schema tool enables autoscale of RU for all tables: RU 
 
 Azure Cosmos DB automatically takes backups of your data at regular intervals. The automatic backups are taken without affecting the performance or availability of the database operations. All the backups are stored separately in a storage service. 
 
-More information can be found in [Backup and Restore in Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/online-backup-and-restore) document.
+More information can be found in [Backup and Restore in Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/online-backup-and-restore) documentation.
 
 ### Monitor Cosmos DB
 
@@ -73,7 +73,7 @@ In this section, you will set up an Azure Database for MySQL servers for Scalar 
 
 ### Steps
 
-* Create an Azure Database for MySQL servers using the [official document](https://docs.microsoft.com/en-us/azure/mysql/quickstart-create-mysql-server-database-using-azure-portal).
+* Create an Azure Database for MySQL servers on the base of [Azure official guide](https://docs.microsoft.com/en-us/azure/mysql/quickstart-create-mysql-server-database-using-azure-portal).
 
 ### Configure Scalar DL 
 
@@ -110,7 +110,7 @@ For servers with more than 100 GB of provisioned storage, the provisioned storag
 
 Azure Database for MySQL automatically creates server backups and stores them in user configured locally redundant or geo-redundant storage. Backups can be used to restore your server to a point-in-time. 
 
-More information can be found in [Backup and restore in Azure Database for MySQL](https://docs.microsoft.com/en-us/azure/mysql/concepts-backup) document.
+More information can be found in [Backup and restore in Azure Database for MySQL](https://docs.microsoft.com/en-us/azure/mysql/concepts-backup) documentation.
 
 ### Monitor MySQL
 
@@ -128,7 +128,7 @@ In this section, you will set up an Azure Database for PostgreSQL servers for Sc
 
 ### Steps
 
-* Create an Azure Database for PostgreSQL servers using the [official document](https://docs.microsoft.com/en-us/azure/postgresql/quickstart-create-server-database-portal).
+* Create an Azure Database for PostgreSQL servers on the base of [Azure official guide](https://docs.microsoft.com/en-us/azure/postgresql/quickstart-create-server-database-portal).
 
 ### Configure Scalar DL 
 
@@ -166,7 +166,7 @@ For servers with more than 100 GB of provisioned storage, the provisioned storag
 Azure Database for PostgreSQL automatically creates server backups and stores them in user configured locally redundant or geo-redundant storage. 
 Backups can be used to restore your server to a point-in-time. 
 
-More information can be found in [Backup and restore in Azure Database for PostgreSQL](https://docs.microsoft.com/en-us/azure/postgresql/concepts-backup) document.
+More information can be found in [Backup and restore in Azure Database for PostgreSQL](https://docs.microsoft.com/en-us/azure/postgresql/concepts-backup) documentation.
 
 
 ### Monitor PostgreSQL

--- a/docs/SetupAzureDatabase.md
+++ b/docs/SetupAzureDatabase.md
@@ -51,8 +51,126 @@ Autoscale provisioned throughput in Azure Cosmos DB allows you to scale the thro
 The throughput is scaled based on the usage, without impacting the availability, latency, throughput, or performance of the workload.
 By default, the scalardl schema tool enables autoscale of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload.
 
+### Backup and Restore
+
+Azure Cosmos DB automatically takes backups of your data at regular intervals. The automatic backups are taken without affecting the performance or availability of the database operations. All the backups are stored separately in a storage service. 
+
+More information can be found in [Backup and Restore in Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/online-backup-and-restore) document.
+
 ### Monitor Cosmos DB
 
 By default, monitoring is enabled on Cosmos DB.
 
 More information can be found in [Monitor Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/monitor-cosmos-db) documentation.
+
+## MySQL
+
+In this section, you will set up an Azure Database for MySQL servers for Scalar DL.
+
+### Requirements
+
+* You must create an Azure Database for MySQL servers with the plan `Single server`.
+
+### Steps
+
+* Create an Azure Database for MySQL servers using the [official document](https://docs.microsoft.com/en-us/azure/mysql/quickstart-create-mysql-server-database-using-azure-portal).
+
+### Configure Scalar DL 
+
+To apply the Scalar DL schema to MySQL, update the following configuration in [schema-loading-custom-values](https://github.com/scalar-labs/scalar-kubernetes/blob/master/conf/schema-loading-custom-values.yaml)
+
+```yaml
+database: jdbc
+contactPoints: <JDBC connection url>
+username: <MySQL username>
+password: <MySQL password>
+```
+
+To deploy Scalar DL on MySQL, update the following configuration in [scalardl-custom-values](https://github.com/scalar-labs/scalar-kubernetes/blob/master/conf/scalardl-custom-values.yaml) 
+
+```yaml
+dbContactPoints: <JDBC connection url>
+dbUsername: <MySQL username>
+dbPassword: <MySQL password>
+dbStorage: jdbc
+```
+
+### Scale resources
+
+After you create your server, you can independently change the vCores, the hardware generation, the pricing tier (except to and from Basic), the amount of storage, and the backup retention period. 
+The number of vCores can be scaled up or down. The storage size can only be increased. Scaling of the resources can be done either through the portal or Azure CLI.
+
+#### Storage auto-grow
+
+Storage auto-grow prevents your server from running out of storage and becoming read-only. If storage auto grow is enabled, the storage automatically grows without impacting the workload. 
+For servers with less than equal to 100 GB provisioned storage, the provisioned storage size is increased by 5 GB when the free storage is below 10% of the provisioned storage.
+For servers with more than 100 GB of provisioned storage, the provisioned storage size is increased by 5% when the free storage space is below the greater of 10 GB or 5% of the provisioned storage size. 
+
+### Backup and Restore
+
+Azure Database for MySQL automatically creates server backups and stores them in user configured locally redundant or geo-redundant storage. Backups can be used to restore your server to a point-in-time. 
+
+More information can be found in [Backup and restore in Azure Database for MySQL](https://docs.microsoft.com/en-us/azure/mysql/concepts-backup) document.
+
+### Monitor MySQL
+
+By default, monitoring is enabled on Azure Database for MySQL servers.
+
+More information can be found in [Monitoring in Azure Database for MySQL](https://docs.microsoft.com/en-us/azure/mysql/concepts-monitoring) documentation.
+
+## PostgreSQL
+
+In this section, you will set up an Azure Database for PostgreSQL servers for Scalar DL.
+
+### Requirements
+
+* You must create an Azure Database for PostgreSQL servers with the plan `Single server`.
+
+### Steps
+
+* Create an Azure Database for PostgreSQL servers using the [official document](https://docs.microsoft.com/en-us/azure/postgresql/quickstart-create-server-database-portal).
+
+### Configure Scalar DL 
+
+To apply the Scalar DL schema to PostgreSQL, update the following configuration in [schema-loading-custom-values](https://github.com/scalar-labs/scalar-kubernetes/blob/master/conf/schema-loading-custom-values.yaml)
+
+```yaml
+database: jdbc
+contactPoints: <PostgreSQL connection url>
+username: <PostgreSQL username>
+password: <PostgreSQL password>
+```
+
+To deploy Scalar DL on PostgreSQL, update the following configuration in [scalardl-custom-values](https://github.com/scalar-labs/scalar-kubernetes/blob/master/conf/scalardl-custom-values.yaml) 
+
+```yaml
+dbContactPoints: <PostgreSQL connection url>
+dbUsername: <PostgreSQL username>
+dbPassword: <PostgreSQL password>
+dbStorage: jdbc
+```
+
+### Scale resources
+
+After you create your server, you can independently change the vCores, the hardware generation, the pricing tier (except to and from Basic), the amount of storage, and the backup retention period. 
+The number of vCores can be scaled up or down. The storage size can only be increased. Scaling of the resources can be done either through the portal or Azure CLI.
+
+#### Storage auto-grow
+
+Storage auto-grow prevents your server from running out of storage and becoming read-only. If storage auto grow is enabled, the storage automatically grows without impacting the workload. 
+For servers with less than equal to 100 GB provisioned storage, the provisioned storage size is increased by 5 GB when the free storage is below 10% of the provisioned storage.
+For servers with more than 100 GB of provisioned storage, the provisioned storage size is increased by 5% when the free storage space is below the greater of 10 GB or 5% of the provisioned storage size. 
+
+### Backup and Restore
+
+Azure Database for PostgreSQL automatically creates server backups and stores them in user configured locally redundant or geo-redundant storage. 
+Backups can be used to restore your server to a point-in-time. 
+
+More information can be found in [Backup and restore in Azure Database for PostgreSQL](https://docs.microsoft.com/en-us/azure/postgresql/concepts-backup) document.
+
+
+### Monitor PostgreSQL
+
+By default, monitoring is enabled on Azure Database for PostgreSQL servers.
+
+More information can be found in [Monitor and tune Azure Database for PostgreSQL](https://docs.microsoft.com/en-us/azure/postgresql/concepts-monitoring) documentation.


### PR DESCRIPTION
JDBC support integrated into the azure manual scalar dl deployment guide.  
Content of the `Scale resources` section is the same in both MySQL and PostgreSQL but I think it's better to keep both.

Better to merge after integrating the latest scalardl version (scalar db 3.0.0 support) in helm-chats.
