### PR TITLE
Update to make auditor schema applicable and make the corresponding chart runnable without the custom config

### DIFF
--- a/conf/schema-loading-custom-values.yaml
+++ b/conf/schema-loading-custom-values.yaml
@@ -8,6 +8,7 @@ schemaLoading:
   username: cassandra
   password: cassandra
   cassandraReplicationFactor: 3
+  cassandraReplicationStrategy: NetworkTopologyStrategy
 
   #
   # Cosmos DB
@@ -25,3 +26,8 @@ schemaLoading:
   # username: <AWS_ACCESS_KEY_ID>
   # password: <AWS_ACCESS_SECRET_KEY>
   # dynamoBaseResourceUnit: 10
+
+  #
+  # General
+  #
+  #schemaType: ledger

--- a/conf/schema-loading-custom-values.yaml
+++ b/conf/schema-loading-custom-values.yaml
@@ -30,4 +30,4 @@ schemaLoading:
   #
   # General
   #
-  #schemaType: ledger
+  # schemaType: ledger


### PR DESCRIPTION
Updates that correspond to [the PR](https://github.com/scalar-labs/helm-charts/pull/17/).