### PR TITLE
Update scalar dl manual deployment guide for auditor service on EKS

### DIFF
--- a/docs/ManualDeploymentGuideScalarDLOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAWS.md
@@ -138,7 +138,7 @@ Note that they are going to be versioned in the future, so you might want to cha
     helm upgrade --version <chart version> --install my-release-scalardl scalar-labs/scalardl --namespace default -f scalardl-custom-values.yaml
    ```
    
- 5. [Optional] Run the Helm commands on the bastion to install Scalar DL auditor on AKS.
+ 5. [Optional] Run the Helm commands on the bastion to install Scalar DL auditor on EKS.
    
     ```console
     # Load schema for Scalar DL auditor install with a release name `load-schema`

--- a/docs/ManualDeploymentGuideScalarDLOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAWS.md
@@ -7,8 +7,6 @@ This guide shows you how to manually deploy Scalar DL on a managed database serv
 Scalar DL Auditor is an optional component that manages the identical states of Ledger to help clients to detect Byzantine faults. 
 Using Auditor brings great benefit from the security perspective but it comes with extra processing costs.
 
-Note: Optional sections are mandatory to enable the auditor service.
-
 ## What we create
 
 ![image](images/network_diagram_eks.png)
@@ -153,6 +151,7 @@ Note that they are going to be versioned in the future, so you might want to cha
 Note:
 
 * The same commands can be used to upgrade the pods.
+* Optional steps are mandatory to enable the auditor service.
 * Release name `my-release-scalardl` can be changed as per your convenience.
 * Release name `my-release-scalardl-audit` can be changed at your convenience.
 * The `chart version` can be obtained from `helm search repo scalar-labs` output

--- a/docs/ManualDeploymentGuideScalarDLOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAWS.md
@@ -7,7 +7,7 @@ This guide shows you how to manually deploy Scalar DL on a managed database serv
 Scalar DL Auditor is an optional component that manages the identical states of Ledger to help clients to detect Byzantine faults. 
 Using Auditor brings great benefit from the security perspective but it comes with extra processing costs.
 
-_Note:- Optional sections are mandatory to enable the audit service._
+Note: Optional sections are mandatory to enable the auditor service.
 
 ## What we create
 
@@ -114,7 +114,7 @@ The following steps show how to install Scalar DL on EKS:
 1. Download the following Scalar DL configuration files from the [scalar-kubernetes repository](https://github.com/scalar-labs/scalar-kubernetes/tree/master/conf).
 Note that they are going to be versioned in the future, so you might want to change the branch to use a proper version.
     * scalardl-custom-values.yaml
-    * scalardl-audit-custom-values.yaml [optional]
+    * scalardl-audit-custom-values.yaml [Optional]
     * schema-loading-custom-values.yaml
  
 2. Update the database configuration in `scalarLedgerConfiguration`, `scalarAuditorConfiguration` and `schemaLoading` sections as specified in [configure Scalar DL guide](./ConfigureScalarDL.md).
@@ -140,14 +140,14 @@ Note that they are going to be versioned in the future, so you might want to cha
     helm upgrade --version <chart version> --install my-release-scalardl scalar-labs/scalardl --namespace default -f scalardl-custom-values.yaml
    ```
    
- 5. [optional] Run the Helm commands on the bastion to install Scalar DL auditor on AKS.
+ 5. [Optional] Run the Helm commands on the bastion to install Scalar DL auditor on AKS.
    
     ```console
     # Load schema for Scalar DL auditor install with a release name `load-schema`
-      helm upgrade --version <chart version> --install load-schema-audit scalar-labs/schema-loading --namespace default -f schema-loading-custom-values.yaml --set schemaLoading.schemaType=auditor
+    helm upgrade --version <chart version> --install load-schema-audit scalar-labs/schema-loading --namespace default -f schema-loading-custom-values.yaml --set schemaLoading.schemaType=auditor
     
     # Install Scalar DL with a release name `my-release-scalardl`
-      helm upgrade --version <chart version> --install my-release-scalardl-audit scalar-labs/scalardl-audit --namespace default -f scalardl-audit-custom-values.yaml
+    helm upgrade --version <chart version> --install my-release-scalardl-audit scalar-labs/scalardl-audit --namespace default -f scalardl-audit-custom-values.yaml
     ```
 
 Note:

--- a/docs/ManualDeploymentGuideScalarDLOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAWS.md
@@ -99,11 +99,11 @@ Install the Helm on your bastion to deploy helm-charts:
 
 * [Helm](https://helm.sh/docs/intro/install/): helm command-line tool to manage releases in the EKS cluster. In this tutorial, it is used to deploy Scalar DL and Schema loading helm charts to the EKS cluster. Helm version 3.5 or latest is required.
 * You must create a Github Personal Access Token (PAT) on the basis of [Github official document](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-  with `read:packages` scope, it is used to access the `scalar-ledger` and `scalardl-schema-loader` container images from GitHub Packages.
+  with `read:packages` scope, it is used to access the `scalar-ledger`, `scalar-auditor` and `scalardl-schema-loader` container images from GitHub Packages.
 
 ### Requirements
 
-* You must have the authority to pull `scalar-ledger` and `scalardl-schema-loader` container images.
+* You must have the authority to pull `scalar-ledger`, `scalar-auditor` and `scalardl-schema-loader` container images.
 * You must configure the database properties in the helm chart custom values file.
 * You must confirm that the replica count of the ledger and envoy pods in the `scalardl-custom-values.yaml` file is equal to the number of nodes in the Scalar DL node group.
 


### PR DESCRIPTION
Update the scalar dl manual deployment guide for auditor deployment. The auditor service is an optional service.

We can merge it after the release of the helm charts and docker images supported by the auditor.