### PR TITLE
Disable the default monitoring custom configuration values

### DIFF
--- a/conf/scalardl-audit-custom-values.yaml
+++ b/conf/scalardl-audit-custom-values.yaml
@@ -2,13 +2,13 @@ envoy:
   replicaCount: 3
 
   prometheusRule:
-    enabled: true
+    enabled: false
 
   serviceMonitor:
-    enabled: true
+    enabled: false
 
   grafanaDashboard:
-    enabled: true
+    enabled: false
 
   service:
     type: LoadBalancer
@@ -85,13 +85,13 @@ auditor:
     # auditorLedgerHost: <the service endpoint of ledger-side envoy>
 
   prometheusRule:
-    enabled: true
+    enabled: false
 
   serviceMonitor:
-    enabled: true
+    enabled: false
 
   grafanaDashboard:
-    enabled: true
+    enabled: false
 
   nodeSelector: {}
 

--- a/conf/scalardl-custom-values.yaml
+++ b/conf/scalardl-custom-values.yaml
@@ -2,13 +2,13 @@ envoy:
   replicaCount: 3
 
   prometheusRule:
-    enabled: true
+    enabled: false
 
   serviceMonitor:
-    enabled: true
+    enabled: false
 
   grafanaDashboard:
-    enabled: true
+    enabled: false
 
   service:
     type: LoadBalancer
@@ -86,13 +86,13 @@ ledger:
     # ledgerAuditorEnabled: true
 
   prometheusRule:
-    enabled: true
+    enabled: false
 
   serviceMonitor:
-    enabled: true
+    enabled: false
 
   grafanaDashboard:
-    enabled: true
+    enabled: false
 
   nodeSelector: {}
 


### PR DESCRIPTION
Current Scalar DL Ledger and Auditor deployment guide do not support Scalar DL specific monitoring services. We will create a monitoring guide soon.

If these values are true, we need to create a namespace and deploy Prometheus.