### PR TITLE
Update Network ACLs rules for Scalar DL Auditor deployment

### DIFF
--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -66,20 +66,20 @@ so you need to add peering for internal communication between the Auditor, Ledge
 * Update route tables for VPC peering connection based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
 * Add new Inbound and Outbound rules to restrict unwanted access to Ledger and Auditor.
     * Add new Inbound rules to Ledger Network ACLs to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from the Auditor and Client.
-        * You must set high priority to this rule.
+        * You must set high priority to these rules.
     * Add new Inbound rules to Ledger Network ACLs to restrict access to all ports except ephemeral ports from the Auditor and Client.
+        * You must set the next priority to these rules.
+    * Add new Inbound rule to Ledger Network ACLs to allow all access from the internet.
         * You must set the next priority to this rule.
-    * Add new Inbound rules to Ledger Network ACLs to allow all access from the internet.
-        * You must set the next priority to this rule.
-    * Add new Outbound rules to Ledger Network ACLs to allow all access to the internet.
+    * Add new Outbound rule to Ledger Network ACLs to allow all access to the internet.
     * Add all Ledger subnets to subnet associations of Ledger Network ACLs.
     * Add new Inbound rules to Auditor Network ACLs to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from the Ledger and Client.
-        * You must set high priority to this rule.
+        * You must set high priority to these rules.
     * Add new Inbound rules to Auditor Network ACLs to restrict access to all ports except ephemeral ports from the Ledger and Client.
+        * You must set the next priority to these rules.
+    * Add new Inbound rule to Auditor Network ACLs to allow all access from the internet.
         * You must set the next priority to this rule.
-    * Add new Inbound rules to Auditor Network ACLs to allow all access from the internet.
-        * You must set the next priority to this rule.
-    * Add new Outbound rules to Auditor Network ACLs to allow all access to the internet.
+    * Add new Outbound rule to Auditor Network ACLs to allow all access to the internet.
     * Add all Auditor subnets to subnet associations of Auditor Network ACLs.
 
 Note: - We expect you have created the Client VPC for your application deployment.

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -70,7 +70,7 @@ so you need to add peering for internal communication between the Auditor, Ledge
     * Add a new Inbound rule to allow ephemeral ports 1024–65535 access from the internet.
         * You must set the next priority to this rule.
     * Add a new Outbound rule to allow all access to the internet.
-    * Add private subnets of Ledger and Auditor to subnet associations of the appropriate Network ACLs.
+    * Add private subnets of Ledger and Auditor to the subnet associations of the respective Network ACLs.
 
 Note: - We expect you have created the Client VPC for your application deployment.
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -71,15 +71,15 @@ so you need to add peering for internal communication between the Auditor, Ledge
         * You must set the next priority to this rule.
     * Add new Inbound rules to Ledger Network ACLs to allow all access from the internet.
         * You must set the next priority to this rule.
-    * Add new Outbound rules to the Ledger Network ACLs to allow all access to the internet.
+    * Add new Outbound rules to Ledger Network ACLs to allow all access to the internet.
     * Add all Ledger subnets to subnet associations of Ledger Network ACLs.
     * Add new Inbound rules to Auditor Network ACLs to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from the Ledger and Client.
         * You must set high priority to this rule.
     * Add new Inbound rules to Auditor Network ACLs to restrict access to all ports except ephemeral ports from the Ledger and Client.
         * You must set the next priority to this rule.
-    * Add new Inbound rules to Ledger Network ACLs to allow all access from the internet.
+    * Add new Inbound rules to Auditor Network ACLs to allow all access from the internet.
         * You must set the next priority to this rule.
-    * Add new Outbound rules to the Auditor Network ACLs to allow all access to the internet.
+    * Add new Outbound rules to Auditor Network ACLs to allow all access to the internet.
     * Add all Auditor subnets to subnet associations of Auditor Network ACLs.
 
 Note: - We expect you have created the Client VPC for your application deployment.

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -59,28 +59,33 @@ so you need to add peering for internal communication between the Auditor, Ledge
 
 ### Steps
 
-* Create 3 peering connections between the Ledger, Auditor and Client VPCs based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html).
+* Create three peering connections between the Ledger, Auditor and Client VPCs based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html).
     * Peering between Ledger and Auditor.
     * Peering between Ledger and Client.
     * Peering between Auditor and Client.
 * Update route tables for VPC peering connection based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
-* Add new Inbound and Outbound rules to restrict unwanted access to Ledger and Auditor.
+* Add new Inbound and Outbound rules to restrict unwanted access to the Ledger.
     * Add new Inbound rules to Ledger Network ACLs to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from the Auditor and Client.
         * You must set high priority to these rules.
-    * Add new Inbound rules to Ledger Network ACLs to restrict access to all ports except ephemeral ports from the Auditor and Client.
+    * Add new Inbound rules to Ledger Network ACLs to restrict all access from the Auditor and Client.
         * You must set the next priority to these rules.
-    * Add new Inbound rule to Ledger Network ACLs to allow all access from the internet.
+    * Add a new Inbound rule to Ledger Network ACLs to allow all access from the same Ledger VPC
         * You must set the next priority to this rule.
-    * Add new Outbound rule to Ledger Network ACLs to allow all access to the internet.
-    * Add all Ledger subnets to subnet associations of Ledger Network ACLs.
+    * Add a new Inbound rule to Ledger Network ACLs to allow ephemeral ports (1024–65535) access from the internet.
+        * You must set the next priority to this rule.
+    * Add a new Outbound rule to Ledger Network ACLs to allow all access to the internet.
+    * Add Ledger private subnets to subnet associations of the Ledger Network ACLs.
+* Add new Inbound and Outbound rules to restrict unwanted access to the Auditor.
     * Add new Inbound rules to Auditor Network ACLs to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from the Ledger and Client.
         * You must set high priority to these rules.
-    * Add new Inbound rules to Auditor Network ACLs to restrict access to all ports except ephemeral ports from the Ledger and Client.
+    * Add new Inbound rules to Auditor Network ACLs to restrict all access from the Ledger and Client.
         * You must set the next priority to these rules.
-    * Add new Inbound rule to Auditor Network ACLs to allow all access from the internet.
+    * Add a new Inbound rule to Auditor Network ACLs to allow all access from the same Auditor VPC.
         * You must set the next priority to this rule.
-    * Add new Outbound rule to Auditor Network ACLs to allow all access to the internet.
-    * Add all Auditor subnets to subnet associations of Auditor Network ACLs.
+    * Add a new Inbound rule to Auditor Network ACLs to allow ephemeral ports (1024–65535) access from the internet.
+        * You must set the next priority to this rule.
+    * Add a new Outbound rule to Auditor Network ACLs to allow all access to the internet.
+    * Add Auditor private subnets to subnet associations of the Auditor Network ACLs.
 
 Note: - We expect you have created the Client VPC for your application deployment.
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -64,7 +64,7 @@ so you need to add peering for internal communication between the Auditor, Ledge
     * Peering between Ledger and Client.
     * Peering between Auditor and Client.
 * Update route tables for VPC peering connection based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
-* Add new Inbound and Outbound rule to restrict unwanted access to Ledger and Auditor.
+* Add new Inbound and Outbound rules to restrict unwanted access to Ledger and Auditor.
     * Add new Inbound rules to Ledger Network ACLs to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from Auditor and Client.
         * You must set high priority to this rule.
     * Add new Inbound rules to Ledger Network ACLs to restrict all ports except ephemeral ports from Auditor and Client.

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -64,27 +64,27 @@ so you need to add peering for internal communication between the Auditor, Ledge
     * Peering between Ledger and Client.
     * Peering between Auditor and Client.
 * Update route tables for VPC peering connection based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
-* Add new Inbound and Outbound rules to restrict unwanted access to the Ledger.
-    * Add new Inbound rules to Ledger Network ACLs to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from the Auditor and Client.
+* Add new Inbound and Outbound rules to Ledger Network ACLs to restrict unwanted access to the Ledger.
+    * Add new Inbound rules to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from the Auditor and Client.
         * You must set high priority to these rules.
-    * Add new Inbound rules to Ledger Network ACLs to restrict all access from the Auditor and Client.
+    * Add new Inbound rules to restrict all access from the Auditor and Client.
         * You must set the next priority to these rules.
-    * Add a new Inbound rule to Ledger Network ACLs to allow all access from the same Ledger VPC
+    * Add a new Inbound rule to allow all access from the same Ledger VPC.
         * You must set the next priority to this rule.
-    * Add a new Inbound rule to Ledger Network ACLs to allow ephemeral ports (1024–65535) access from the internet.
+    * Add a new Inbound rule to allow ephemeral ports (1024–65535) access from the internet.
         * You must set the next priority to this rule.
-    * Add a new Outbound rule to Ledger Network ACLs to allow all access to the internet.
+    * Add a new Outbound rule to allow all access to the internet.
     * Add Ledger private subnets to subnet associations of the Ledger Network ACLs.
-* Add new Inbound and Outbound rules to restrict unwanted access to the Auditor.
-    * Add new Inbound rules to Auditor Network ACLs to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from the Ledger and Client.
+* Add new Inbound and Outbound rules to Auditor Network ACLs to restrict unwanted access to the Auditor.
+    * Add new Inbound rules to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from the Ledger and Client.
         * You must set high priority to these rules.
-    * Add new Inbound rules to Auditor Network ACLs to restrict all access from the Ledger and Client.
+    * Add new Inbound rules to restrict all access from the Ledger and Client.
         * You must set the next priority to these rules.
-    * Add a new Inbound rule to Auditor Network ACLs to allow all access from the same Auditor VPC.
+    * Add a new Inbound rule to allow all access from the same Auditor VPC.
         * You must set the next priority to this rule.
-    * Add a new Inbound rule to Auditor Network ACLs to allow ephemeral ports (1024–65535) access from the internet.
+    * Add a new Inbound rule to allow ephemeral ports (1024–65535) access from the internet.
         * You must set the next priority to this rule.
-    * Add a new Outbound rule to Auditor Network ACLs to allow all access to the internet.
+    * Add a new Outbound rule to allow all access to the internet.
     * Add Auditor private subnets to subnet associations of the Auditor Network ACLs.
 
 Note: - We expect you have created the Client VPC for your application deployment.

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -64,28 +64,13 @@ so you need to add peering for internal communication between the Auditor, Ledge
     * Peering between Ledger and Client.
     * Peering between Auditor and Client.
 * Update route tables for VPC peering connection based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
-* Add new Inbound and Outbound rules to Ledger Network ACLs to restrict unwanted access to the Ledger.
-    * Add new Inbound rules to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from the Auditor and Client.
-        * You must set high priority to these rules.
-    * Add new Inbound rules to restrict all access from the Auditor and Client.
-        * You must set the next priority to these rules.
-    * Add a new Inbound rule to allow all access from the same Ledger VPC.
-        * You must set the next priority to this rule.
-    * Add a new Inbound rule to allow ephemeral ports (1024–65535) access from the internet.
+* Add new Inbound and Outbound rules to Ledger Network ACLs and Auditor Network ACLs to restrict unwanted access to the Ledger and Auditor.
+    * Add a new Inbound rule to allow all access from the same VPC.
+        * You must set high priority to this rule.
+    * Add a new Inbound rule to allow ephemeral ports 1024–65535 access from the internet.
         * You must set the next priority to this rule.
     * Add a new Outbound rule to allow all access to the internet.
-    * Add Ledger private subnets to subnet associations of the Ledger Network ACLs.
-* Add new Inbound and Outbound rules to Auditor Network ACLs to restrict unwanted access to the Auditor.
-    * Add new Inbound rules to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from the Ledger and Client.
-        * You must set high priority to these rules.
-    * Add new Inbound rules to restrict all access from the Ledger and Client.
-        * You must set the next priority to these rules.
-    * Add a new Inbound rule to allow all access from the same Auditor VPC.
-        * You must set the next priority to this rule.
-    * Add a new Inbound rule to allow ephemeral ports (1024–65535) access from the internet.
-        * You must set the next priority to this rule.
-    * Add a new Outbound rule to allow all access to the internet.
-    * Add Auditor private subnets to subnet associations of the Auditor Network ACLs.
+    * Add private subnets of Ledger and Auditor to subnet associations of the appropriate Network ACLs.
 
 Note: - We expect you have created the Client VPC for your application deployment.
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -65,17 +65,17 @@ so you need to add peering for internal communication between the Auditor, Ledge
     * Peering between Auditor and Client.
 * Update route tables for VPC peering connection based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
 * Add new Inbound and Outbound rules to restrict unwanted access to Ledger and Auditor.
-    * Add new Inbound rules to Ledger Network ACLs to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from Auditor and Client.
+    * Add new Inbound rules to Ledger Network ACLs to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from the Auditor and Client.
         * You must set high priority to this rule.
-    * Add new Inbound rules to Ledger Network ACLs to restrict all ports except ephemeral ports from Auditor and Client.
+    * Add new Inbound rules to Ledger Network ACLs to restrict access to all ports except ephemeral ports from the Auditor and Client.
         * You must set the next priority to this rule.
     * Add new Inbound rules to Ledger Network ACLs to allow all access from the internet.
         * You must set the next priority to this rule.
     * Add new Outbound rules to the Ledger Network ACLs to allow all access to the internet.
     * Add all Ledger subnets to subnet associations of Ledger Network ACLs.
-    * Add new Inbound rules to Auditor Network ACLs to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from Ledger and Client.
+    * Add new Inbound rules to Auditor Network ACLs to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from the Ledger and Client.
         * You must set high priority to this rule.
-    * Add new Inbound rules to Auditor Network ACLs to restrict all ports except ephemeral ports from Ledger and Client.
+    * Add new Inbound rules to Auditor Network ACLs to restrict access to all ports except ephemeral ports from the Ledger and Client.
         * You must set the next priority to this rule.
     * Add new Inbound rules to Ledger Network ACLs to allow all access from the internet.
         * You must set the next priority to this rule.

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -65,22 +65,22 @@ so you need to add peering for internal communication between the Auditor, Ledge
     * Peering between Auditor and Client.
 * Update route tables for VPC peering connection based on the [AWS official guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
 * Add new Inbound and Outbound rule to restrict unwanted access to Ledger and Auditor.
-    * Add new Inbound rules to the Ledger Network ACLs to allow the Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) access from the Auditor and Client.
+    * Add new Inbound rules to Ledger Network ACLs to allow ephemeral ports (1024–65535) to access Ledger Envoy LoadBalancer (e.g., 50051 and 50052 by default) from Auditor and Client.
         * You must set high priority to this rule.
-    * Add new Inbound rules to the Ledger Network ACLs to allow ssh access from the internet.
-        * You must set second priority to this rule.
-    * Add new Inbound rules to Ledger Network ACLs to allow all access to Ledger VPC.
-        * You must set third priority to this rule.
+    * Add new Inbound rules to Ledger Network ACLs to restrict all ports except ephemeral ports from Auditor and Client.
+        * You must set the next priority to this rule.
+    * Add new Inbound rules to Ledger Network ACLs to allow all access from the internet.
+        * You must set the next priority to this rule.
     * Add new Outbound rules to the Ledger Network ACLs to allow all access to the internet.
-    * Add Ledger private subnets to subnet associations of the Ledger Network ACLs.
-    * Add new Inbound rules to the Auditor Network ACLs to allow the Auditor Envoy LoadBalancer (e.g., 40051, 40052 by default) access from the Ledger and Client.
+    * Add all Ledger subnets to subnet associations of Ledger Network ACLs.
+    * Add new Inbound rules to Auditor Network ACLs to allow ephemeral ports (1024–65535) to access Auditor Envoy LoadBalancer (e.g., 40051 and 40052 by default) from Ledger and Client.
         * You must set high priority to this rule.
-    * Add new Inbound rules to the Auditor Network ACLs to allow ssh access from the internet.
-        * You must set second priority to this rule.
-    * Add new Inbound rules to Auditor Network ACLs to allow all access to Auditor VPC.
-        * You must set third priority to this rule.
+    * Add new Inbound rules to Auditor Network ACLs to restrict all ports except ephemeral ports from Ledger and Client.
+        * You must set the next priority to this rule.
+    * Add new Inbound rules to Ledger Network ACLs to allow all access from the internet.
+        * You must set the next priority to this rule.
     * Add new Outbound rules to the Auditor Network ACLs to allow all access to the internet.
-    * Add Auditor private subnets to subnet associations of the Auditor Network ACLs.
+    * Add all Auditor subnets to subnet associations of Auditor Network ACLs.
 
 Note: - We expect you have created the Client VPC for your application deployment.
 


### PR DESCRIPTION
Update NACL rule for Scalar DL deployment with Ledger and Auditor.

The current rule did not allow communication between Ledger and Auditor.

```
NACL is stateless, which means that it needs both an outbound rule and also an inbound rule for allowing traffic. The port range is always set for the destination port. Thus, when the application instance in Ledger VPC generates traffic for your instance in Auditor VPC, it will have the destination port as either 40051 or 40052, however, the source port would be a random port from the ephemeral port range of 1024 - 65535. So we need to allow ephemeral port range.
```