### PR TITLE
Create AWS supported database guide for Scalar DB/Scalar DL manual deployment guides

### DIFF
--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -4,18 +4,26 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 ## DynamoDB
 
-By default, Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
+By default, Amazon DynamoDB is available for all AWS users. The Scalar DL/Scalar DB schema loader will set the required configurations while creating the schema. You do not need to set up anything manually.
 
 ### Steps
 
-* Create a schema and configure DynamoDB properties like autoscale, Read and Write Request Unit,
-  * For Scalar DL, [Scalar DL schema loader](https://github.com/scalar-labs/scalardl-schema-loader) or schema-loading [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to create schema and configure properties like autoscale, Read and Write Request Unit for DynamoDB tables.
-  * For Scalar DB, [Scalar DB schema loader](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/) will help you to create the schema and configure properties like autoscale, Read and WriteRequest Unit for DynamoDB tables.
-* (Optional) You can scale the throughput of DynamoDB by setting the `dynamoBaseResourceUnit` value (which applies to all the tables) in the `schema-loading-custom-values.yaml` file.
 * (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
+
+
+## AWS RDS for MySQL, PostgreSQL, Oracle, SQL Server
+
+In this section, you will create an AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server.
+
+### Steps
+
+* Follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to create a database instance.
+* (Optional) To increase or autoscale storage, follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html). 
+* (Optional) Configure advanced monitoring services with [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html), monitoring is enabled by default.
 
 Note:-
 
-* Scalar DL and Scalar DB schema loader sets the same value to both Read and Write Request Units (The default Read and Write Request Unit is 10).
-  
-* The Scalar DL and Scalar DB schema loader enable auto-scaling of Request Units for all tables by default.
+* You can scale up or scale down the instance and memory used. In addition, AWS also has the option to provide additional storage.
+* You can autoscale IOPS up to a threshold you set if you select `Provisioned IOPS SSD` as the `storage type`.
+
+

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -4,7 +4,7 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 ## DynamoDB
 
-Amazon DynamoDB is readily available to use in AWS. You do not need to set up anything manually.
+Amazon DynamoDB is available for use in AWS by default. You do not need to set up anything manually to use it.
 
 ### Optional steps
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -4,7 +4,7 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 ## DynamoDB
 
-Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
+Amazon DynamoDB is readily available to use in AWS. You do not need to set up anything manually.
 
 ### Optional steps
 
@@ -25,7 +25,7 @@ In this section, you will create an AWS RDS for MySQL/PostgreSQL/Oracle/SQL Serv
 * (Optional) Configure advanced monitoring services with the [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html), monitoring is enabled by default on AWS RDS database instances.
 
 Note:-
-* Baseline I/O performance for General Purpose SSD storage is 3 IOPS/GB, choose adequate storage to match your performance requirements.
+* Baseline I/O performance for General Purpose SSD ( gp2 ) storage is 3 IOPS/GB, choose adequate storage to match your performance requirements.
 * If you choose `Provisioned IOPS SSD` as the `storage type`, it will scale the IOPS up to a selected limit.
 
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -13,7 +13,7 @@ Amazon DynamoDB is available for all AWS users. You do not need to set up anythi
 
 Note:-
 
-* Scalar DB/DL schema loader will configure same Read/Write Capacity for all tables.
+* Scalar DB/DL schema loader will configure the same Read/Write Capacity for all tables.
 
 ## AWS RDS for MySQL, PostgreSQL, Oracle, SQL Server
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -8,13 +8,12 @@ By default, Amazon DynamoDB is available for all AWS users. You do not need to s
 
 ### Steps
 
-* For configuring DynamoDB properties like autoscale, Read and WriteRequest Unit,
-  * For Scalar DL, [Scalar DL schema loader](https://github.com/scalar-labs/scalardl-schema-loader) or the Scalar DL schema loader [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to configure properties like autoscale, Read and WriteRequest Unit for DynamoDB tables.
-  * For Scalar DB, [Scalar DB schema loader](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/) will help you to configure properties like autoscale, Read and WriteRequest Unit for DynamoDB tables.
+* Create a schema and configure DynamoDB properties like autoscale, Read and Write Request Unit,
+  * For Scalar DL, [Scalar DL schema loader](https://github.com/scalar-labs/scalardl-schema-loader) or schema-loading [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to create schema and configure properties like autoscale, Read and Write Request Unit for DynamoDB tables.
+  * For Scalar DB, [Scalar DB schema loader](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/) will help you to create the schema and configure properties like autoscale, Read and WriteRequest Unit for DynamoDB tables.
 * (Optional) You can scale the throughput of DynamoDB by setting the `dynamoBaseResourceUnit` value (which applies to all the tables) in the `schema-loading-custom-values.yaml` file.
 * (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
 
 Note:-
 
-* Scalar DL schema loader sets the same value to both Read and Write Request Units (The default Read and Write Request Unit is 10).
-* By default, the `Scalar DL schema loader` enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload.
+* Scalar DL and Scalar DB schema loader sets the same value to both Read and Write Request Units (The default Read and Write Request Unit is 10).

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -9,9 +9,10 @@ Amazon DynamoDB is available for all AWS users. You do not need to set up anythi
 ### Optional Steps
 
 * Configure advanced monitoring services with the [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
-* You can change the `Read/Write Capacity` of a DynamoDB table according to your requirement.
+* You can change the `Read/Write Capacity` of DynamoDB tables based on your requirements.
 
 Note:-
+
 * Scalar DB/DL schema loader will configure same Read/Write Capacity for all tables.
 
 ## AWS RDS for MySQL, PostgreSQL, Oracle, SQL Server

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -8,10 +8,9 @@ By default, Amazon DynamoDB is available for all AWS users. You do not need to s
 
 ### Steps
 
-* For configuring DynamoDB,
-  * For Scalar DL, [Scalar DL schema loader](https://github.com/scalar-labs/scalardl-schema-loader) or the Scalar DL schema loader [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to configure DynamoDB.
-  * For Scalar DB, [Scalar DB schema loader](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/) will help you to configure DynamoDB.
-
+* For configuring DynamoDB properties like autoscale, Read and WriteRequest Unit,
+  * For Scalar DL, [Scalar DL schema loader](https://github.com/scalar-labs/scalardl-schema-loader) or the Scalar DL schema loader [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to configure properties like autoscale, Read and WriteRequest Unit for DynamoDB tables.
+  * For Scalar DB, [Scalar DB schema loader](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/) will help you to configure properties like autoscale, Read and WriteRequest Unit for DynamoDB tables.
 * (Optional) You can scale the throughput of DynamoDB by setting the `dynamoBaseResourceUnit` value (which applies to all the tables) in the `schema-loading-custom-values.yaml` file.
 * (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -8,7 +8,7 @@ By default, Amazon DynamoDB is available for all AWS users. You do not need to c
 Scalar schema loader [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to configure DynamoDB.
 
 * (Optional) You can scale the throughput of DynamoDB by setting the `dynamoBaseResourceUnit` value (which applies to all the tables) in the `schema-loading-custom-values.yaml` file.
-* (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), by default monitoring is enabled in DynamoDB.
+* (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
 
 WARNING:
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -4,7 +4,7 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 ## DynamoDB
 
-By default, Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
+Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
 
 ### Steps
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -9,23 +9,17 @@ Amazon DynamoDB is available for use in AWS by default. You do not need to set u
 ### Optional steps
 
 * Configure advanced monitoring services with the [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
-* You can change the `Read/Write Capacity` of DynamoDB tables based on your requirements.
+* You should change the `Read/Write Capacity` of DynamoDB tables based on your requirements.
 
 Note:-
 
 * Scalar DB/DL schema loader will configure the same Read/Write Capacity for all tables.
 
-## AWS RDS for MySQL, PostgreSQL, Oracle, SQL Server
+## AWS RDS for MySQL, PostgreSQL, Oracle and SQL Server
 
-In this section, you will create an AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server.
+In this section, you will create an AWS RDS instance for MySQL/PostgreSQL/Oracle/SQL Server.
 
 ### Steps
 
 * Follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to create an AWS RDS MySQL/PostgreSQL/Oracle/SQL Server database instance.
 * (Optional) Configure advanced monitoring services with the [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html), monitoring is enabled by default on AWS RDS database instances.
-
-Note:-
-* Baseline I/O performance for General Purpose SSD ( gp2 ) storage is 3 IOPS/GB, choose adequate storage to match your performance requirements.
-* If you choose `Provisioned IOPS SSD` as the `storage type`, it will scale the IOPS up to a selected limit.
-
-

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -17,8 +17,6 @@ Note:-
 
 ## AWS RDS for MySQL, PostgreSQL, Oracle and SQL Server
 
-In this section, you will create an AWS RDS instance for MySQL/PostgreSQL/Oracle/SQL Server.
-
 ### Steps
 
 * Follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to create an AWS RDS MySQL/PostgreSQL/Oracle/SQL Server database instance.

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -17,3 +17,5 @@ By default, Amazon DynamoDB is available for all AWS users. You do not need to s
 Note:-
 
 * Scalar DL and Scalar DB schema loader sets the same value to both Read and Write Request Units (The default Read and Write Request Unit is 10).
+  
+* The Scalar DL and Scalar DB schema loader enable auto-scaling of Request Units for all tables by default.

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -1,0 +1,20 @@
+# Set up a database for Scalar DB/Scalar DL deployment on AWS
+
+This guide explains how to set up a database for Scalar DB/Scalar DL deployment on AWS.
+
+## DynamoDB
+
+By default, Amazon DynamoDB is available for all AWS users. You do not need to configure anything manually.
+Scalar schema loader [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to configure DynamoDB.
+
+* (Optional) You can scale the throughput of DynamoDB by setting the `dynamoBaseResourceUnit` value (which applies to all the tables) in the `schema-loading-custom-values.yaml` file.
+* (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), by default monitoring is enabled in DynamoDB.
+
+WARNING:
+
+* Scalar schema loader sets the same value to both Read and Write Request Units.
+* By default, the Read and Write Request Unit is 10.
+
+Note:-
+
+* By default, the `scalar DL schema loader` enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload.

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -4,17 +4,18 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 ## DynamoDB
 
-By default, Amazon DynamoDB is available for all AWS users. You do not need to configure anything manually.
-Scalar schema loader [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to configure DynamoDB.
+By default, Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
+
+### Steps
+
+* For configuring DynamoDB,
+  * For Scalar DL, [Scalar DL schema loader](https://github.com/scalar-labs/scalardl-schema-loader) or the Scalar DL schema loader [helm charts](https://github.com/scalar-labs/helm-charts/tree/main/charts/schema-loading) will help you to configure DynamoDB.
+  * For Scalar DB, [Scalar DB schema loader](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/) will help you to configure DynamoDB.
 
 * (Optional) You can scale the throughput of DynamoDB by setting the `dynamoBaseResourceUnit` value (which applies to all the tables) in the `schema-loading-custom-values.yaml` file.
 * (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
 
-WARNING:
-
-* Scalar schema loader sets the same value to both Read and Write Request Units.
-* By default, the Read and Write Request Unit is 10.
-
 Note:-
 
-* By default, the `scalar DL schema loader` enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload.
+* Scalar DL schema loader sets the same value to both Read and Write Request Units (The default Read and Write Request Unit is 10).
+* By default, the `Scalar DL schema loader` enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload.

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -4,12 +4,12 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 ## DynamoDB
 
-By default, Amazon DynamoDB is available for all AWS users. The Scalar DL/Scalar DB schema loader will set the required configurations while creating the schema. You do not need to set up anything manually.
+By default, Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
 
 ### Steps
 
-* (Optional)  Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
-
+* (Optional) Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
+* (Optional) You can change the `Read/Write Capacity` of a DynamoDB table according to your requirement.
 
 ## AWS RDS for MySQL, PostgreSQL, Oracle, SQL Server
 
@@ -17,13 +17,11 @@ In this section, you will create an AWS RDS for MySQL/PostgreSQL/Oracle/SQL Serv
 
 ### Steps
 
-* Follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to create a database instance.
-* (Optional) To increase or autoscale storage, follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html). 
-* (Optional) Configure advanced monitoring services with [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html), monitoring is enabled by default.
+* Follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to create an AWS RDS MySQL/PostgreSQL/Oracle/SQL Server database instance.
+* (Optional) Configure advanced monitoring services with [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html), monitoring is enabled by default on AWS RDS database instances.
 
 Note:-
-
-* You can scale up or scale down the instance and memory used. In addition, AWS also has the option to provide additional storage.
-* You can autoscale IOPS up to a threshold you set if you select `Provisioned IOPS SSD` as the `storage type`.
+* Baseline I/O performance for General Purpose SSD storage is 3 IOPS/GB, choose adequate storage to match your performance requirements.
+* You can autoscale IOPS up to a chosen limit if you select `Provisioned IOPS SSD` as the `storage type`.
 
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -6,10 +6,13 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
 
-### Steps
+### Optional Steps
 
-* (Optional) Configure advanced monitoring services with [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
-* (Optional) You can change the `Read/Write Capacity` of a DynamoDB table according to your requirement.
+* Configure advanced monitoring services with the [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
+* You can change the `Read/Write Capacity` of a DynamoDB table according to your requirement.
+
+Note:-
+* Scalar DB/DL schema loader will configure same Read/Write Capacity for all tables.
 
 ## AWS RDS for MySQL, PostgreSQL, Oracle, SQL Server
 
@@ -18,10 +21,10 @@ In this section, you will create an AWS RDS for MySQL/PostgreSQL/Oracle/SQL Serv
 ### Steps
 
 * Follow this [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html) to create an AWS RDS MySQL/PostgreSQL/Oracle/SQL Server database instance.
-* (Optional) Configure advanced monitoring services with [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html), monitoring is enabled by default on AWS RDS database instances.
+* (Optional) Configure advanced monitoring services with the [AWS official guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html), monitoring is enabled by default on AWS RDS database instances.
 
 Note:-
 * Baseline I/O performance for General Purpose SSD storage is 3 IOPS/GB, choose adequate storage to match your performance requirements.
-* You can autoscale IOPS up to a chosen limit if you select `Provisioned IOPS SSD` as the `storage type`.
+* If you choose `Provisioned IOPS SSD` as the `storage type`, you can set IOPS to a specified limit.
 
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -25,6 +25,6 @@ In this section, you will create an AWS RDS for MySQL/PostgreSQL/Oracle/SQL Serv
 
 Note:-
 * Baseline I/O performance for General Purpose SSD storage is 3 IOPS/GB, choose adequate storage to match your performance requirements.
-* If you choose `Provisioned IOPS SSD` as the `storage type`, you can set IOPS to a specified limit.
+* If you choose `Provisioned IOPS SSD` as the `storage type`, it will scale the IOPS up to a selected limit.
 
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -6,7 +6,7 @@ This guide explains how to set up a database for Scalar DB/Scalar DL deployment 
 
 Amazon DynamoDB is available for all AWS users. You do not need to set up anything manually.
 
-### Optional Steps
+### Optional steps
 
 * Configure advanced monitoring services with the [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
 * You can change the `Read/Write Capacity` of DynamoDB tables based on your requirements.


### PR DESCRIPTION
I have created a guide to setting up databases for Scalar DL/Scalar DB in AWS. I had added DynamoDB as the first database in this document. But after making updates as per [PR](https://github.com/scalar-labs/scalar-kubernetes/pull/171) feedback the DynamoDB section was reduced to a few sentences. So I have added the AWS RDS databases section and created this new PR.

Check if all requirements are met
Check if the goal has been achieved
Check if you understand what you are explaining perfectly
Check if all the sentences are clear, concise, easy-to-understand, and well-thought English
Make sure there are no spelling mistakes and grammatical errors (some grammar issues exist which were shown in Grammarly which were difficult to resolve)