### PR TITLE
Update configure scalar DL document

### DIFF
--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -19,8 +19,8 @@ You need to create a secret object with `db-username` and `db-password` to store
     # password=<AWS_ACCESS_SECRET_KEY>
 
 # JDBC Databases
-   # username=<ACCOUNT_USERNAME>
-   # password=<ACCOUNT_PASSWORD>
+   # username=<USERNAME>
+   # password=<PASSWORD>
     
 kubectl create secret generic scalardl --from-literal db-username=<username> --from-literal db-password=<password>
 ```

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -28,13 +28,13 @@ kubectl create secret generic scalardl --from-literal db-username=<username> --f
 ```
 Note-:
 
-For Cosmos DB, use account name as `username` since we can't leave the `db-uername` property empty.
+For Cosmos DB, use the account name as `username` since we can't leave the `db-uername` property empty.
 
 ### Configure schema-loading-custom-values
 
 To create a Scalar DL schema in Cosmos DB, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
 You can refer to the [section](#kubernetes-secret-and-schema-loading-reference) to check which values are needed based on the database used.
-If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that configuration property.
+If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that property from the configuration file.
 
 **With Kubernetes secrets**
 
@@ -80,7 +80,7 @@ You can refer the table below to update the [scalardl-custom-values.yaml](../con
 
 To deploy Scalar DL Ledger on Cosmos DB, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
 You can refer to the [section](#ledger-and-auditor-reference) to check which values are needed based on the database used.
-If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that configuration property.
+If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that property from the configuration file.
 
 **With Kubernetes secrets**
 
@@ -112,7 +112,7 @@ ledger:
 
 To deploy the Scalar DL Auditor on Cosmos DB, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
 You can refer to the [section](#ledger-and-auditor-reference) to check which values are needed based on the database used.
-If any configuration property value is defined as `N/A` in the reference table for your database, you can exclude or remove that property.
+If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that property from the configuration file.
 
 **With Kubernetes Secrets**
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -155,9 +155,9 @@ To enable the Auditor service, update the following configurations in the [scala
 
 ```yaml
 scalarLedgerConfiguration:
-  # To use Auditor
-  ledgerProofEnabled: true
-  ledgerAuditorEnabled: true
+   # To use Auditor
+   ledgerProofEnabled: true
+   ledgerAuditorEnabled: true
 ```
 
 ### Configure scalardl-audit-custom-values

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -5,7 +5,7 @@ This guide explains how to configure Scalar DL custom values in helm charts for 
 
 ## Reference Table
 
-You can refer to the table below to get values to create Kubernetes Secrets and update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file according to the database you chose
+You can refer to the table below to get values to create Kubernetes Secrets and update the configuration files for Scalar DL deployment according to the database you chose.
 
 | Database  | storageType | contactPoints              | username       | password                                 | dynamoBaseResourceUnit | cosmosBaseResourceUnit | 
 |:----------|-------------|----------------------------|----------------|------------------------------------------|------------------------|------------------------|
@@ -25,7 +25,7 @@ Note:-
 
 Kubernetes Secret is an object that contains a small amount of sensitive data such as a password, a token, or a key.
 This optional method is recommended highly for handling credentials in the production environment.
-You can refer to the [reference section](#reference-table) to get the values for `username` and `password` for the database you chose.
+You can refer to the [reference table](#reference-table) section to get the values for `username` and `password` for the database you chose.
 You need to create a secret object with `db-username` and `db-password` to store the username and password of the underlying database.
 
 
@@ -41,8 +41,8 @@ For Cosmos DB, use the Cosmos DB account name as `username`.
 ### Configure schema-loading-custom-values
 
 To create a Scalar DL schema in the database, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
-You can refer to the [section](#reference-table) to check which values are needed based on the database used.
-If any configuration property value is defined as `N/A` in the reference table for your database, you need to remove that property from the configuration file.
+You can refer to the [reference table](#reference-table) section to check which values are needed based on the database used.
+If any configuration property value is defined as `N/A` in the [reference table](#reference-table) section for your database, you must remove that property from the configuration file.
 
 **With Kubernetes secrets**
 
@@ -76,7 +76,7 @@ schemaLoading:
 ### Configure scalardl-custom-values
 
 To deploy Scalar DL Ledger, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
-You can refer to the [section](#reference-table) to check which values are needed based on the database used.
+You can refer to the [reference table](#reference-table) section to check which values are needed based on the database used.
 
 **With Kubernetes secrets**
 
@@ -111,7 +111,7 @@ For Cosmos DB, you need to remove the `dbUsername` property as it is not require
 ### Configure scalardl-audit-custom-values
 
 To deploy the Scalar DL Auditor, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
-You can refer to the [section](#reference-table) to check which values are needed based on the database used.
+You can refer to the [reference table](#reference-table) section to check which values are needed based on the database used.
 
 **With Kubernetes Secrets**
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -18,14 +18,12 @@ You need to create a secret object with `db-username` and `db-password` to store
     # username=<AWS_ACCESS_KEY_ID>
     # password=<AWS_ACCESS_SECRET_KEY>
 
-# AWS RDS Databases(MySQL PostgreSQL, Oracle, SQL Server, Aurora), Azure Databases for MySQL, PostgreSQL
+# JDBC Databases
    # username=<ACCOUNT_USERNAME>
    # password=<ACCOUNT_PASSWORD>
     
 kubectl create secret generic scalardl --from-literal db-username=<username> --from-literal db-password=<password>
 ```
-**Note**:- 
-* For Azure Database for MySQL use <ACCOUNT_USERNAME@HOST_NAME> instead of <ACCOUNT_USERNAME> as `username` value.
 
 ## Update Configuration Files 
 
@@ -89,7 +87,7 @@ ledger:
     dbStorage: cosmos
 ```
 
-To enable Auditor service, you can follow the [Enable Auditor](#enable-auditor) section.
+To enable the Auditor service, you can follow the [Enable Auditor](#enable-auditor) section.
 
 #### Configure scalardl-audit-custom-values
 
@@ -221,16 +219,11 @@ auditor:
 
 To enable the Auditor service, you can follow the [Enable Auditor](#enable-auditor) section.
 
-### AWS RDS Databases(MySQL PostgreSQL, Oracle, SQL Server, Aurora), Azure Databases for MySQL, PostgreSQL
-
-#### Requirements
-
-* The JDBC connection URL (`JDBC_CONNECTION_URL`) format may vary according to the cloud service provider and database you choose. Please check the official documentation and confirm the connection URL format.
-* For `Azure Database for MySQL` use <ACCOUNT_USERNAME@HOST_NAME> instead of <ACCOUNT_USERNAME> for `username` and `dbUsername` values when updating the configuration files.
+### JDBC Databases
 
 #### Configure schema-loading-custom-values
 
-To create the Scalar DL schema in AWS RDS databases, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
+To create the Scalar DL schema in JDBC databases, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
 
 **With Kubernetes secrets**
 
@@ -252,13 +245,13 @@ If you have not created the `scalardl` Kubernetes secret, you can use the follow
 schemaLoading:
   database: jdbc
   contactPoints: <JDBC_CONNECTION_URL>
-  username: <ACCOUNT_USERNAME>
-  password: <ACCOUNT_PASSWORD>
+  username: <USERNAME>
+  password: <PASSWORD>
 ```
 
 #### Configure scalardl-custom-values
 
-To deploy the Scalar DL Ledger on AWS RDS databases, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
+To deploy the Scalar DL Ledger on JDBC databases, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
 
 **With Kubernetes secrets**
 
@@ -283,15 +276,15 @@ ledger:
   scalarLedgerConfiguration:
     dbStorage: jdbc
     dbContactPoints: <JDBC_CONNECTION_URL>
-    dbUsername: <ACCOUNT_USERNAME>
-    dbPassword: <ACCOUNT_PASSWORD>
+    dbUsername: <USERNAME>
+    dbPassword: <PASSWORD>
 ```
 
 To enable the Auditor service, you can follow the [Enable Auditor](#enable-auditor) section.
 
 #### Configure scalardl-audit-custom-values
 
-To deploy the Scalar DL Auditor on any AWS RDS databases, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
+To deploy the Scalar DL Auditor on JDBC databases, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
 
 **With Kubernetes secrets**
 
@@ -316,8 +309,8 @@ auditor:
   scalarAuditorConfiguration:
     dbStorage: jdbc
     dbContactPoints: <JDBC_CONNECTION_URL>
-    dbUsername: <ACCOUNT_USERNAME>
-    dbPassword: <ACCOUNT_PASSWORD>
+    dbUsername: <USERNAME>
+    dbPassword: <PASSWORD>
 ```
 
 ### Enable Auditor 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -13,13 +13,10 @@ You can refer to the table below to get values to create Kubernetes Secrets and 
 | Cosmos DB | cosmos      | Cosmos DB account endpoint | N/A            | Cosmos DB account primary/secondary key  | N/A                    | 400                    |
 | JDBC      | jdbc        | JDBC_CONNECTION_URL        | USERNAME       | PASSWORD                                 | N/A                    | N/A                    |
 
-Note:- 
+Note:
 
 * JDBC denotes all relational databases supported by Scalar DL such as 
-  * MySQL, PostgreSQL, Oracle DB and SQL Server 
-  * AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server
-  * Amazon Aurora MySQL/PostgreSQL
-  * Azure Database for MySQL/PostgreSQL
+  * MySQL, PostgreSQL, Oracle DB and SQL Server
 
 ## Create Kubernetes Secrets
 
@@ -32,7 +29,7 @@ You need to create a secret object with `db-username` and `db-password` to store
 ```
 kubectl create secret generic scalardl --from-literal db-username=<username> --from-literal db-password=<password>
 ```
-Note-:
+Note:
 
 For Cosmos DB, use the Cosmos DB account name as `username`.
 
@@ -104,7 +101,7 @@ ledger:
     dbStorage: <storageType>
 ```
 
-Note:-
+Note:
 
 For Cosmos DB, you need to remove the `dbUsername` property as it is not required.
 
@@ -140,7 +137,7 @@ auditor:
     dbStorage: <storageType>
 ```
 
-Note:-
+Note:
 
 For Cosmos DB, you need to remove the `dbUsername` property as it is not required.
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -14,8 +14,10 @@ You can refer to the table below to get values to create Kubernetes Secrets and 
 | JDBC      | jdbc        | JDBC_CONNECTION_URL        | USERNAME       | PASSWORD                                 | N/A                    | N/A                    |
 
 Note:- 
-* JDBC denotes all relational databases such as MySQL, PostgreSQL, Oracle DB and SQL Server.
-* For Azure MySQL, please provide the username in the `username@hostname` form.
+* JDBC denotes all relational databases suppoerted by Scalar DL such as 
+  * MySQL, PostgreSQL, Oracle DB and SQL Server 
+  * AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server
+  * Azure Database for MySQL/PostgreSQL.
 
 ## Create Kubernetes Secrets
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -2,24 +2,26 @@
 
 This guide explains how to configure Scalar DL custom values in helm charts for Scalar DL deployment.
 
-## Update Configuration Files
 
-### Kubernetes Secrets and Schema Loading reference
+## Reference Table
 
 You can refer to the table below to get values to create Kubernetes Secrets and update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file according to the database you chose
 
-| Database  | database | contactPoints              | username          | password                                      | dynamoBaseResourceUnit | cosmosBaseResourceUnit | 
-|:----------|----------|----------------------------|-------------------|-----------------------------------------------|------------------------|------------------------|
-| DynamoDB  | dynamo   | REGION                     | AWS_ACCESS_KEY_ID | AWS_ACCESS_SECRET_KEY                         | 10                     | N/A                    |
-| Cosmos DB | cosmos   | Cosmos DB account endpoint | N/A               | Cosmos DB account primary/secondary key | N/A                    | 400                    |
-| JDBC      | jdbc     | JDBC_CONNECTION_URL        | USERNAME          | PASSWORD                                      | N/A                    | N/A                    |
+| Database  | storageType | contactPoints              | username       | password                                 | dynamoBaseResourceUnit | cosmosBaseResourceUnit | 
+|:----------|-------------|----------------------------|----------------|------------------------------------------|------------------------|------------------------|
+| DynamoDB  | dynamo      | REGION                     | AWS_ACCESS_KEY | AWS_ACCESS_SECRET_KEY                    | 10                     | N/A                    |
+| Cosmos DB | cosmos      | Cosmos DB account endpoint | N/A            | Cosmos DB account primary/secondary key  | N/A                    | 400                    |
+| JDBC      | jdbc        | JDBC_CONNECTION_URL        | USERNAME       | PASSWORD                                 | N/A                    | N/A                    |
 
+Note:- 
+* JDBC denotes all relational databases such as MySQL, PostgreSQL, Oracle DB and SQL Server.
+* For Azure MySQL, please provide the username in the `username@hostname` form.
 
-### Create Kubernetes Secrets
+## Create Kubernetes Secrets
 
 Kubernetes Secret is an object that contains a small amount of sensitive data such as a password, a token, or a key.
-This optional method is highly recommended for handling credentials in the production environment.
-You can refer to the [section](#kubernetes-secret-and-schema-loading-reference) to get the values for `username` and `password` for the database you chose.
+This optional method is recommended highly for handling credentials in the production environment.
+You can refer to the [section](#reference-table) to get the values for `username` and `password` for the database you chose.
 You need to create a secret object with `db-username` and `db-password` to store the username and password of the underlying database.
 
 
@@ -30,10 +32,12 @@ Note-:
 
 For Cosmos DB, use the Cosmos DB account name as `username`.
 
+## Update Configuration Files
+
 ### Configure schema-loading-custom-values
 
 To create a Scalar DL schema in the database, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
-You can refer to the [section](#kubernetes-secret-and-schema-loading-reference) to check which values are needed based on the database used.
+You can refer to the [section](#reference-table) to check which values are needed based on the database used.
 If any configuration property value is defined as `N/A` in the reference table for your database, you need to remove that property from the configuration file.
 
 **With Kubernetes secrets**
@@ -44,8 +48,8 @@ If you have created the `scalardl` Kubernetes secret, you can use the following 
 schemaLoading:
   existingSecret: scalardl
   
-  database: <database>
-  contactPoints: <dbContactPoints>
+  database: <storageType>
+  contactPoints: <contactPoints>
   cosmosBaseResourceUnit: <cosmosBaseResourceUnit>
   dynamoBaseResourceUnit: <dynamoBaseResourceUnit>
   
@@ -57,29 +61,18 @@ If you have not created the `scalardl` Kubernetes secret, you can use the follow
 
 ```yaml
 schemaLoading:
-  database: <database>
-  contactPoints: <dbContactPoints>
+  database: <storageType>
+  contactPoints: <contactPoints>
   username: <username>
   password: <password>
   cosmosBaseResourceUnit: <cosmosBaseResourceUnit>
   dynamoBaseResourceUnit: <dynamoBaseResourceUnit>
 ```
 
-### Ledger and Auditor reference
-
-You can refer the table below to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) and [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file according to the database of you chose for deployment.
-
-| Database  | dbStorage | dbContactPoints            | dbUsername        | dbPassword                           |
-|:----------|-----------|----------------------------|-------------------|--------------------------------------|
-| DynamoDB  | dynamo    | REGION                     | AWS_ACCESS_KEY_ID | AWS_ACCESS_SECRET_KEY                |
-| Cosmos DB | cosmos    | Cosmos DB account endpoint | N/A               | Cosmos DB account primary/secondary key |
-| JDBC      | jdbc      | JDBC_CONNECTION_URL        | USERNAME          | PASSWORD                             |
-
-
 ### Configure scalardl-custom-values
 
 To deploy Scalar DL Ledger, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
-You can refer to the [section](#ledger-and-auditor-reference) to check which values are needed based on the database used.
+You can refer to the [section](#reference-table) to check which values are needed based on the database used.
 
 **With Kubernetes secrets**
 
@@ -90,8 +83,8 @@ ledger:
   existingSecret: scalardl
   ....
   scalarLedgerConfiguration:
-    dbContactPoints: <dbContactPoints>
-    dbStorage: <dbStorage>
+    dbContactPoints: <contactPoints>
+    dbStorage: <storageType>
 ```
 **Without Kubernetes secrets**
 
@@ -101,20 +94,20 @@ If you have not created the `scalardl` Kubernetes secret, you can use the follow
 ledger:
   ....
   scalarLedgerConfiguration:
-    dbContactPoints: <dbContactPoints>
-    dbUsername: <dbUsername>
-    dbPassword: <dbPassword>
-    dbStorage: <dbStorage>
+    dbContactPoints: <contactPoints>
+    dbUsername: <username>
+    dbPassword: <password>
+    dbStorage: <storageType>
 ```
 
 Note:-
 
-For Cosmos DB, you need to remove `dbUsername` property as it is not required.
+For Cosmos DB, you need to remove `username` property as it is not required.
 
 ### Configure scalardl-audit-custom-values
 
 To deploy the Scalar DL Auditor, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
-You can refer to the [section](#ledger-and-auditor-reference) to check which values are needed based on the database used.
+You can refer to the [section](#reference-table) to check which values are needed based on the database used.
 
 **With Kubernetes Secrets**
 
@@ -125,8 +118,8 @@ auditor:
   existingSecret: scalardl
   ....
   scalarAuditorConfiguration:
-    dbContactPoints: <dbContactPoints>
-    dbStorage: <dbStorage>
+    dbContactPoints: <contactPoints>
+    dbStorage: <storageType>
 ```
 
 **Without Kubernetes secrets**
@@ -137,15 +130,15 @@ If you have not created the `scalardl` Kubernetes secret, you can use the follow
 auditor:
   ....
   scalarAuditorConfiguration:
-    dbContactPoints: <dbContactPoints>
-    dbUsername: <dbUsername>
-    dbPassword: <dbPassword>
-    dbStorage: <dbStorage>
+    dbContactPoints: <contactPoints>
+    dbUsername: <username>
+    dbPassword: <password>
+    dbStorage: <storageType>
 ```
 
 Note:-
 
-For using Cosmos DB, you need to remove `dbUsername` property as it is not required.
+For Cosmos DB, you need to remove the `username` property as it is not required.
 
 ## Enable Auditor
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -9,7 +9,7 @@ You can refer to the table below to get values to create Kubernetes Secrets and 
 
 | Database  | storageType | contactPoints              | username       | password                                 | dynamoBaseResourceUnit | cosmosBaseResourceUnit | 
 |:----------|-------------|----------------------------|----------------|------------------------------------------|------------------------|------------------------|
-| DynamoDB  | dynamo      | REGION                     | AWS_ACCESS_KEY | AWS_ACCESS_SECRET_KEY                    | 10                     | N/A                    |
+| DynamoDB  | dynamo      | AWS_REGION                 | AWS_ACCESS_KEY | AWS_ACCESS_SECRET_KEY                    | 10                     | N/A                    |
 | Cosmos DB | cosmos      | Cosmos DB account endpoint | N/A            | Cosmos DB account primary/secondary key  | N/A                    | 400                    |
 | JDBC      | jdbc        | JDBC_CONNECTION_URL        | USERNAME       | PASSWORD                                 | N/A                    | N/A                    |
 
@@ -18,14 +18,15 @@ Note:-
 * JDBC denotes all relational databases supported by Scalar DL such as 
   * MySQL, PostgreSQL, Oracle DB and SQL Server 
   * AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server
-  * Azure Database for MySQL/PostgreSQL.
+  * Amazon Aurora MySQL/PostgreSQL
+  * Azure Database for MySQL/PostgreSQL
 * For Azure Database for PostgreSQL, please add `/postgres` after the port number (example: `jdbc:postgresql://connection_endpoint:5432/postgres`) for `JDBC_CONNECTION_URL`.
 
 ## Create Kubernetes Secrets
 
 Kubernetes Secret is an object that contains a small amount of sensitive data such as a password, a token, or a key.
 This optional method is recommended highly for handling credentials in the production environment.
-You can refer to the [section](#reference-table) to get the values for `username` and `password` for the database you chose.
+You can refer to the [reference section](#reference-table) to get the values for `username` and `password` for the database you chose.
 You need to create a secret object with `db-username` and `db-password` to store the username and password of the underlying database.
 
 
@@ -106,7 +107,7 @@ ledger:
 
 Note:-
 
-For Cosmos DB, you need to remove `username` property as it is not required.
+For Cosmos DB, you need to remove the `dbUsername` property as it is not required.
 
 ### Configure scalardl-audit-custom-values
 
@@ -142,7 +143,7 @@ auditor:
 
 Note:-
 
-For Cosmos DB, you need to remove the `username` property as it is not required.
+For Cosmos DB, you need to remove the `dbUsername` property as it is not required.
 
 ## Enable Auditor
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -20,7 +20,6 @@ Note:-
   * AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server
   * Amazon Aurora MySQL/PostgreSQL
   * Azure Database for MySQL/PostgreSQL
-* For Azure Database for PostgreSQL, please add `/postgres` after the port number (example: `jdbc:postgresql://connection_endpoint:5432/postgres`) for `JDBC_CONNECTION_URL`.
 
 ## Create Kubernetes Secrets
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -28,7 +28,7 @@ kubectl create secret generic scalardl --from-literal db-username=<username> --f
 ```
 Note-:
 
-For Cosmos DB, use the account name as `username` since we can't leave the `db-uername` property empty.
+For Cosmos DB, use the Cosmos DB account name as `username`.
 
 ### Configure schema-loading-custom-values
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -14,10 +14,12 @@ You can refer to the table below to get values to create Kubernetes Secrets and 
 | JDBC      | jdbc        | JDBC_CONNECTION_URL        | USERNAME       | PASSWORD                                 | N/A                    | N/A                    |
 
 Note:- 
+
 * JDBC denotes all relational databases supported by Scalar DL such as 
   * MySQL, PostgreSQL, Oracle DB and SQL Server 
   * AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server
   * Azure Database for MySQL/PostgreSQL.
+* For Azure Database for PostgreSQL, please add `/postgres` after the port number (example: `jdbc:postgresql://connection_endpoint:5432/postgres`) for `JDBC_CONNECTION_URL`.
 
 ## Create Kubernetes Secrets
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -15,8 +15,7 @@ You can refer to the table below to get values to create Kubernetes Secrets and 
 
 Note:
 
-* JDBC denotes all relational databases supported by Scalar DL such as 
-  * MySQL, PostgreSQL, Oracle DB and SQL Server
+* JDBC denotes all relational databases supported by Scalar DL such as MySQL, PostgreSQL, Oracle Database, SQL Server, and Amazon Aurora.
 
 ## Create Kubernetes Secrets
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -14,7 +14,7 @@ You can refer to the table below to get values to create Kubernetes Secrets and 
 | JDBC      | jdbc        | JDBC_CONNECTION_URL        | USERNAME       | PASSWORD                                 | N/A                    | N/A                    |
 
 Note:- 
-* JDBC denotes all relational databases suppoerted by Scalar DL such as 
+* JDBC denotes all relational databases supported by Scalar DL such as 
   * MySQL, PostgreSQL, Oracle DB and SQL Server 
   * AWS RDS for MySQL/PostgreSQL/Oracle/SQL Server
   * Azure Database for MySQL/PostgreSQL.

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -18,8 +18,14 @@ You need to create a secret object with `db-username` and `db-password` to store
     # username=<AWS_ACCESS_KEY_ID>
     # password=<AWS_ACCESS_SECRET_KEY>
 
+# AWS RDS Databases(MySQL PostgreSQL, Oracle, SQL Server, Aurora), Azure Databases for MySQL, PostgreSQL
+   # username=<ACCOUNT_USERNAME>
+   # password=<ACCOUNT_PASSWORD>
+    
 kubectl create secret generic scalardl --from-literal db-username=<username> --from-literal db-password=<password>
 ```
+**Note**:- 
+* For Azure Database for MySQL use <ACCOUNT_USERNAME@HOST_NAME> instead of <ACCOUNT_USERNAME> as `username` value.
 
 ## Update Configuration Files 
 
@@ -214,6 +220,105 @@ auditor:
 ```
 
 To enable the Auditor service, you can follow the [Enable Auditor](#enable-auditor) section.
+
+### AWS RDS Databases(MySQL PostgreSQL, Oracle, SQL Server, Aurora), Azure Databases for MySQL, PostgreSQL
+
+#### Requirements
+
+* The JDBC connection URL (`JDBC_CONNECTION_URL`) format may vary according to the cloud service provider and database you choose. Please check the official documentation and confirm the connection URL format.
+* For `Azure Database for MySQL` use <ACCOUNT_USERNAME@HOST_NAME> instead of <ACCOUNT_USERNAME> for `username` and `dbUsername` values when updating the configuration files.
+
+#### Configure schema-loading-custom-values
+
+To create the Scalar DL schema in AWS RDS databases, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
+
+**With Kubernetes secrets**
+
+If you have created the `scalardl` Kubernetes secret, you can use the following configuration.
+
+```yaml
+schemaLoading:
+  existingSecret: scalardl
+
+  database: jdbc
+  contactPoints: <JDBC_CONNECTION_URL>
+```
+
+**Without Kubernetes secrets**
+
+If you have not created the `scalardl` Kubernetes secret, you can use the following configuration.
+
+```yaml
+schemaLoading:
+  database: jdbc
+  contactPoints: <JDBC_CONNECTION_URL>
+  username: <ACCOUNT_USERNAME>
+  password: <ACCOUNT_PASSWORD>
+```
+
+#### Configure scalardl-custom-values
+
+To deploy the Scalar DL Ledger on AWS RDS databases, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
+
+**With Kubernetes secrets**
+
+If you have created the `scalardl` Kubernetes secret, you can use the following configuration.
+
+```yaml
+ledger:
+  existingSecret: scalardl
+  ....
+  scalarLedgerConfiguration:
+    dbStorage: jdbc
+    dbContactPoints: <JDBC_CONNECTION_URL>
+```
+
+**Without Kubernetes secrets**
+
+If you have not created the `scalardl` Kubernetes secret, you can use the following configuration.
+
+```yaml
+ledger:
+  ....
+  scalarLedgerConfiguration:
+    dbStorage: jdbc
+    dbContactPoints: <JDBC_CONNECTION_URL>
+    dbUsername: <ACCOUNT_USERNAME>
+    dbPassword: <ACCOUNT_PASSWORD>
+```
+
+To enable the Auditor service, you can follow the [Enable Auditor](#enable-auditor) section.
+
+#### Configure scalardl-audit-custom-values
+
+To deploy the Scalar DL Auditor on any AWS RDS databases, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
+
+**With Kubernetes secrets**
+
+If you have created the `scalardl` Kubernetes secret, you can use the following configuration.
+
+```yaml
+auditor:
+  existingSecret: scalardl
+  ....
+  scalarAuditorConfiguration:
+    dbStorage: jdbc
+    dbContactPoints: <JDBC_CONNECTION_URL>
+```
+
+**Without Kubernetes secrets**
+
+If you have not created the `scalardl` Kubernetes secret, you can use the following configuration.
+
+```yaml
+auditor:
+  ....
+  scalarAuditorConfiguration:
+    dbStorage: jdbc
+    dbContactPoints: <JDBC_CONNECTION_URL>
+    dbUsername: <ACCOUNT_USERNAME>
+    dbPassword: <ACCOUNT_PASSWORD>
+```
 
 ### Enable Auditor 
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -25,6 +25,9 @@ You need to create a secret object with `db-username` and `db-password` to store
 kubectl create secret generic scalardl --from-literal db-username=<username> --from-literal db-password=<password>
 ```
 
+**Note**:-
+* For Azure Database for MySQL use <USERNAME@HOSTNAME> instead of <USERNAME> for `username` value.
+
 ## Update Configuration Files 
 
 ### Cosmos DB
@@ -220,6 +223,16 @@ auditor:
 To enable the Auditor service, you can follow the [Enable Auditor](#enable-auditor) section.
 
 ### JDBC Databases
+
+The JDBC databases supported by Scalar DL are listed below.
+* AWS RDS for MySQL
+* AWS RDS for PostgreSQL
+* AWS RDS for Oracle
+* AWS RDS for SQL Server
+* Amazon Aurora MySQL
+* Amazon Aurora PostgreSQL
+* Azure Database for MySQL
+* Azure Database for PostgreSQL
 
 #### Configure schema-loading-custom-values
 

--- a/docs/ConfigureScalarDL.md
+++ b/docs/ConfigureScalarDL.md
@@ -6,13 +6,13 @@ This guide explains how to configure Scalar DL custom values in helm charts for 
 
 ### Kubernetes Secrets and Schema Loading reference
 
-You can refer to the table below to get values to set create Kubernetes Secrets and update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file properties file according to the database you chose for deployment.
+You can refer to the table below to get values to create Kubernetes Secrets and update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file according to the database you chose
 
-| Database  | database | contactPoints              | username          | password                             | dynamoBaseResourceUnit | cosmosBaseResourceUnit | 
-|:----------|----------|----------------------------|-------------------|--------------------------------------|------------------------|------------------------|
-| DynamoDB  | dynamo   | REGION                     | AWS_ACCESS_KEY_ID | AWS_ACCESS_SECRET_KEY                | 10                     | N/A                    |
-| Cosmos DB | cosmos   | Cosmos DB account endpoint | N/A               | Cosmos DB account primary master key | N/A                    | 400                    |
-| JDBC      | jdbc     | JDBC_CONNECTION_URL        | USERNAME          | PASSWORD                             | N/A                    | N/A                    |
+| Database  | database | contactPoints              | username          | password                                      | dynamoBaseResourceUnit | cosmosBaseResourceUnit | 
+|:----------|----------|----------------------------|-------------------|-----------------------------------------------|------------------------|------------------------|
+| DynamoDB  | dynamo   | REGION                     | AWS_ACCESS_KEY_ID | AWS_ACCESS_SECRET_KEY                         | 10                     | N/A                    |
+| Cosmos DB | cosmos   | Cosmos DB account endpoint | N/A               | Cosmos DB account primary/secondary key | N/A                    | 400                    |
+| JDBC      | jdbc     | JDBC_CONNECTION_URL        | USERNAME          | PASSWORD                                      | N/A                    | N/A                    |
 
 
 ### Create Kubernetes Secrets
@@ -32,9 +32,9 @@ For Cosmos DB, use the account name as `username` since we can't leave the `db-u
 
 ### Configure schema-loading-custom-values
 
-To create a Scalar DL schema in Cosmos DB, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
+To create a Scalar DL schema in the database, you need to update the [schema-loading-custom-values.yaml](../conf/schema-loading-custom-values.yaml) file.
 You can refer to the [section](#kubernetes-secret-and-schema-loading-reference) to check which values are needed based on the database used.
-If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that property from the configuration file.
+If any configuration property value is defined as `N/A` in the reference table for your database, you need to remove that property from the configuration file.
 
 **With Kubernetes secrets**
 
@@ -72,15 +72,14 @@ You can refer the table below to update the [scalardl-custom-values.yaml](../con
 | Database  | dbStorage | dbContactPoints            | dbUsername        | dbPassword                           |
 |:----------|-----------|----------------------------|-------------------|--------------------------------------|
 | DynamoDB  | dynamo    | REGION                     | AWS_ACCESS_KEY_ID | AWS_ACCESS_SECRET_KEY                |
-| Cosmos DB | cosmos    | Cosmos DB account endpoint | N/A               | Cosmos DB account primary master key |
+| Cosmos DB | cosmos    | Cosmos DB account endpoint | N/A               | Cosmos DB account primary/secondary key |
 | JDBC      | jdbc      | JDBC_CONNECTION_URL        | USERNAME          | PASSWORD                             |
 
 
 ### Configure scalardl-custom-values
 
-To deploy Scalar DL Ledger on Cosmos DB, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
+To deploy Scalar DL Ledger, you need to update the [scalardl-custom-values.yaml](../conf/scalardl-custom-values.yaml) file.
 You can refer to the [section](#ledger-and-auditor-reference) to check which values are needed based on the database used.
-If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that property from the configuration file.
 
 **With Kubernetes secrets**
 
@@ -108,11 +107,14 @@ ledger:
     dbStorage: <dbStorage>
 ```
 
+Note:-
+
+For Cosmos DB, you need to remove `dbUsername` property as it is not required.
+
 ### Configure scalardl-audit-custom-values
 
-To deploy the Scalar DL Auditor on Cosmos DB, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
+To deploy the Scalar DL Auditor, you need to update the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
 You can refer to the [section](#ledger-and-auditor-reference) to check which values are needed based on the database used.
-If any configuration property value is defined as `N/A` in the reference table for your database, you can remove that property from the configuration file.
 
 **With Kubernetes Secrets**
 
@@ -141,6 +143,10 @@ auditor:
     dbStorage: <dbStorage>
 ```
 
+Note:-
+
+For using Cosmos DB, you need to remove `dbUsername` property as it is not required.
+
 ## Enable Auditor
 
 ### Configure scalardl-custom-values
@@ -154,7 +160,7 @@ scalarLedgerConfiguration:
   ledgerAuditorEnabled: true
 ```
 
-#### Configure scalardl-audit-custom-values
+### Configure scalardl-audit-custom-values
 
 Configure the service endpoint of ledger-side envoy in the [scalardl-audit-custom-values.yaml](../conf/scalardl-audit-custom-values.yaml) file.
 


### PR DESCRIPTION
I have updated the ConfigureScalarDL.md guide with added details for configuring scalar DL and Auditor configuration files with  JDBC databases. I have also made changes to the document to reduce the overall size.

- Changed database-wise section for each configuration and updated in a general format.
- Added tables with configuration properties for DynamoDB, Cosmos DB and JDBC databases

