### PR TITLE
Word correction

### DIFF
--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -8,7 +8,7 @@ Amazon DynamoDB is available for use in AWS by default. You do not need to set u
 
 ### Optional steps
 
-* Configure advanced monitoring services with the [Azure official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
+* Configure advanced monitoring services with the [AWS official guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/monitoring-automated-manual.html), monitoring is enabled in DynamoDB by default.
 * You should change the `Read/Write Capacity` of DynamoDB tables based on your requirements.
 
 Note:-


### PR DESCRIPTION
I have changed a wording mistake(Azure instead of AWS) in the `SetupDatabaseForAWS.md` guide.
I noticed it when checking the document. This is a recently created document by myself. 
I am sorry for the mistake and the inconvenience caused.