### PR TITLE
Update scalardb custom values

### DIFF
--- a/conf/scalardb-custom-values.yaml
+++ b/conf/scalardb-custom-values.yaml
@@ -43,7 +43,7 @@ envoy:
                 - key: app.kubernetes.io/name
                   operator: In
                   values:
-                    - scalardb-server
+                    - scalardb
                 - key: app.kubernetes.io/app
                   operator: In
                   values:
@@ -106,7 +106,7 @@ scalardb:
                 - key: app.kubernetes.io/name
                   operator: In
                   values:
-                    - scalardb-server
+                    - scalardb
                 - key: app.kubernetes.io/app
                   operator: In
                   values:

--- a/conf/scalardb-custom-values.yaml
+++ b/conf/scalardb-custom-values.yaml
@@ -43,7 +43,7 @@ envoy:
                 - key: app.kubernetes.io/name
                   operator: In
                   values:
-                    - scalardb
+                    - scalardb-server
                 - key: app.kubernetes.io/app
                   operator: In
                   values:
@@ -106,11 +106,11 @@ scalardb:
                 - key: app.kubernetes.io/name
                   operator: In
                   values:
-                    - scalardb
+                    - scalardb-server
                 - key: app.kubernetes.io/app
                   operator: In
                   values:
-                    - ledger
+                    - scalardb
             topologyKey: kubernetes.io/hostname
           weight: 50
   existingSecret: ""

--- a/conf/scalardb-custom-values.yaml
+++ b/conf/scalardb-custom-values.yaml
@@ -19,7 +19,13 @@ envoy:
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
   resources: {}
-    
+
+  tolerations:
+    - effect: NoSchedule
+        key: kubernetes.io/app
+        operator: Equal
+        value: scalardbpool
+
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,11 +35,26 @@ envoy:
                 operator: In
                 values:
                   - scalardbpool
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - scalardb
+                - key: app.kubernetes.io/app
+                  operator: In
+                  values:
+                    - envoy
+            topologyKey: kubernetes.io/hostname
+          weight: 50
 
 scalardb:
   replicaCount: 3
   storageConfiguration:
-  
+
     #
     # Cosmos DB
     #
@@ -48,9 +69,9 @@ scalardb:
     # username: <AWS_ACCESS_KEY_ID>
     # password: <AWS_ACCESS_SECRET_KEY>
     # storage: dynamo
-    
+
     dbLogLevel: INFO
-    
+
   serviceMonitor:
     enabled: false
 
@@ -59,8 +80,14 @@ scalardb:
 
   grafanaDashboard:
     enabled: false
-    
-  resources: {}  
+
+  resources: {}
+
+  tolerations:
+    - effect: NoSchedule
+      key: kubernetes.io/app
+      operator: Equal
+      value: scalardbpool
 
   affinity:
     nodeAffinity:
@@ -71,4 +98,19 @@ scalardb:
                 operator: In
                 values:
                   - scalardbpool
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - scalardb
+                - key: app.kubernetes.io/app
+                  operator: In
+                  values:
+                    - ledger
+            topologyKey: kubernetes.io/hostname
+          weight: 50
   existingSecret: ""

--- a/conf/scalardb-custom-values.yaml
+++ b/conf/scalardb-custom-values.yaml
@@ -22,9 +22,9 @@ envoy:
 
   tolerations:
     - effect: NoSchedule
-        key: kubernetes.io/app
-        operator: Equal
-        value: scalardbpool
+      key: kubernetes.io/app
+      operator: Equal
+      value: scalardbpool
 
   affinity:
     nodeAffinity:


### PR DESCRIPTION
Updated `scalardb-custom-values.yaml` file with configurations for `podAntiAffinity` and `tolerations` as mentioned in this comment https://github.com/scalar-labs/scalar-kubernetes/pull/175#discussion_r885876064 related to scalar DB deployment guide. I have updated the custom file similar to the current `scalardl-custom-values.yaml` and tested it in deployment.