### PR TITLE
Update links to setup database guide in scalar DL deployment guides

### DIFF
--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAWS.md
@@ -11,8 +11,7 @@ In this guide, we will create the following components for Auditor.
 
 * A VPC with NAT gateway
 * An EKS cluster with two Kubernetes node groups
-* A managed database service
-    * DynamoDB
+  A managed database service supported by Scalar DL.
 * A Bastion instance with a public IP
 * Amazon CloudWatch
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAzure.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAzure.md
@@ -11,8 +11,7 @@ In this guide, we will create the following components for auditor.
 
 * An Azure Virtual Network associated with a Resource Group.
 * An AKS cluster with 2 node pools.
-* A managed database service.
-    * A Cosmos DB Account.
+  A managed database service supported by Scalar DL.
 * A Bastion instance with a public IP.
 * Azure container insights.
 

--- a/docs/ManualDeploymentGuideScalarDLOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAWS.md
@@ -15,8 +15,7 @@ In this guide, we will create the following components.
 
 * A VPC with NAT gateway
 * An EKS cluster with two Kubernetes node groups
-* A managed database service
-    * DynamoDB
+  A managed database service supported by Scalar DL.
 * A Bastion instance with a public IP
 * Amazon CloudWatch
 
@@ -52,7 +51,7 @@ In this section, you will set up a database for Scalar DL.
 
 ### Steps
 
-* Follow [Set up a database guide](./SetupDatabase.md) to set up a database for Scalar DL.
+* Follow [Set up a database guide](./SetupDatabaseForAWS.md) to set up a database for Scalar DL.
 
 ## Step 3. Configure EKS
 

--- a/docs/ManualDeploymentGuideScalarDLOnAzure.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAzure.md
@@ -15,8 +15,7 @@ In this guide, we will create the following components.
 
 * An Azure Virtual Network associated with a Resource Group.
 * An AKS cluster with 2 node pools.
-* A managed database service.
-    * A Cosmos DB Account.
+  A managed database service supported by Scalar DL.
 * A Bastion instance with a public IP.
 * Azure container insights.
 
@@ -57,7 +56,7 @@ In this section, you will set up a database for Scalar DL.
 
 ### Steps
 
-* Follow [Set up a database guide](./SetupDatabase.md) to set up a database for Scalar DL.
+* Follow [Set up a database guide](./SetupDatabaseForAzure.md) to set up a database for Scalar DL.
 
 ## Step 3. Configure AKS
 


### PR DESCRIPTION
I have updated the links to set up database guides in both scalar DL deployment guides for AWS and Azure to set up database guides for AWS and Azure respectively. 