### PR TITLE
Add requirement about `Taints` to the deployment guide

### DIFF
--- a/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -69,6 +69,7 @@ Install the following tools on the bastion for controlling the AKS cluster:
 
 * You must have an AKS cluster with Kubernetes version **1.19** or higher for Scalar DB deployment.
 * You must create a new `user node pool` with the name `scalardbpool` for Scalar DB deployment.
+* You must add Taints `kubernetes.io/app=scalardbpool:NoSchedule` to each worker node.
 * You must create a Kubernetes cluster with `service principal` as the Authentication method.
 * You must create a Kubernetes cluster with `Azure CNI`.
 

--- a/docs/ManualDeploymentGuideScalarDLOnAWS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAWS.md
@@ -69,6 +69,8 @@ Install the following tools on your bastion for controlling the EKS cluster:
 * You must create a Kubernetes cluster with version 1.19 or higher for Scalar DL deployment.
 * You must create a node group with the label, key as `agentpool` and value as `scalardlpool` for Scalar DL deployment.
 * You must add a rule in the EKS security group to **enable HTTPS access (Port 443)** to the private EKS cluster from the bastion server.
+* You must add Taints `kubernetes.io/app=scalardlpool:NoSchedule` to each worker node.
+    * You need to add the Taints using the `kubectl taint node` command after you created the cluster since EKS does not support adding Taints with key `kubernetes.io/app` to the node group.
 
 ### Recommendations
 

--- a/docs/ManualDeploymentGuideScalarDLOnAzure.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAzure.md
@@ -73,6 +73,7 @@ Install the following tools on the bastion for controlling the AKS cluster:
 
 * You must have an AKS cluster with Kubernetes version **1.19** or higher for Scalar DL deployment.
 * You must create a new `user node pool` with the name `scalardlpool` for Scalar DL deployment.
+* You must add Taints `kubernetes.io/app=scalardlpool:NoSchedule` to each worker node.
 * You must create a Kubernetes cluster with `service principal` as the Authentication method.
 * You must create a Kubernetes cluster with `Azure CNI`.
 * You must select the subnet other than `k8s_ingress` subnet for creating the AKS cluster.


### PR DESCRIPTION
This PR adds the explanation of `Taints` to the EKS/AKS deployment guide.
I will reorganize these documents, but I added these sentence since I think it is a critical issue.

If we don't add this `Taints` to the worker node, the pods of Scalar Products will not be deployed with [sample configurations](https://github.com/scalar-labs/scalar-kubernetes/tree/master/conf) since the sample configuration includes toleration to prevent application pods will be deployed to worker node for Scalar Products.

Also, in the [Japanese document](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/JpManualDeploymentGuideScalarDLOnAWS.md#%E8%A6%81%E4%BB%B6-2), I already added the explanation of `Taints`.

Please take a look!