### PR TITLE
Add network peering guide for ScalarDL Auditor mode

### DIFF
--- a/docs/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/NetworkPeeringForScalarDLAuditor.md
@@ -1,35 +1,34 @@
-# Create network peering for Scalar DL Auditor mode
+# Configure Scalar DL Auditor mode for network peering
 
-This document explains how to connect several private networks for ScalarDL Auditor mode. To make ScalarDL Auditor mode work properly, ScalarDL Ledger and ScalarDL Auditor need to connect with each other. 
+This document explains how to connect multiple private networks for ScalarDL Auditor mode to perform network peering. For ScalarDL Auditor mode to work properly, you must connect ScalarDL Ledger to ScalarDL Auditor.
 
-## Private network you must connect
+## Private networks to connect
 
-Depending on your application (client) deployment, you must connect several private networks.
+Depending on your application (client) deployment, you must connect multiple private networks.
 
 ### Connect two private networks
 
-If you deploy your application on the same private network as ScalarDL Ledger or ScalarDL Auditor, you must connect two private networks.
+If you deploy your application (client) on the same private network as ScalarDL Ledger or ScalarDL Auditor, you must connect two private networks.
 
 * [ScalarDL Ledger network] <-> [ScalarDL Auditor network]
 
 ### Connect three private networks
 
-If you deploy your application (client) on another private network than ScalarDL Ledger or ScalarDL Auditor, you must connect three private networks.
+If you deploy your application (client) on a separate private network away from ScalarDL Ledger or ScalarDL Auditor, you must connect three private networks.
 
 * [ScalarDL Ledger network] <-> [ScalarDL Auditor network]
-* [ScalarDL Ledger network] <-> [Application (client) network]
-* [ScalarDL Auditor network] <-> [Application (client) network]
+* [ScalarDL Ledger network] <-> [application (client) network]
+* [ScalarDL Auditor network] <-> [application (client) network]
 
 ## Network requirements
 
 ### IP address ranges
 
-To avoid conflicting IP addresses between several private networks, you must create several private networks with different IP address ranges.
+To avoid conflicting IP addresses between the private networks, you must have private networks with different IP address ranges. For example:
 
-* Example
-    * Private network for ScalarDL Ledger -> 10.1.0.0/16
-    * Private network for ScalarDL Auditor -> 10.2.0.0/16
-    * Private network for application (client) -> 10.3.0.0/16
+* **Private network for ScalarDL Ledger:** 10.1.0.0/16
+* **Private network for ScalarDL Auditor:** 10.2.0.0/16
+* **Private network for application (client):** 10.3.0.0/16
 
 ### Connections
 
@@ -47,16 +46,13 @@ The connections (ports) that are used between ScalarDL Ledger, ScalarDL Auditor,
     * 40051/TCP (Load balancing for Scalar DL Auditor)
     * 40052/TCP (Load balancing for Scalar DL Auditor)
 
-## How to peer the private networks
+Private-network peering
 
-### AWS (VPC peering)
+### Amazon VPC peering
 
-Please refer to the following official document for more details on how to peer the VPCs in the AWS environment.
+For details on how to peer virtual private clouds (VPCs) in an Amazon Web Services (AWS) environment, see the official documentation from Amazon at [Create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html).
 
-* [Create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html)
+### Azure VNet peering
 
-### Azure (Virtual network peering)
+For details on how to peer virtual networks in an Azure environment, see the official documentation from Microsoft at [Virtual network peering](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-peering-overview).
 
-Please refer to the following official document for more details on how to peer the VNets in the Azure environment.
-
-* [Virtual network peering](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-peering-overview)

--- a/docs/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/NetworkPeeringForScalarDLAuditor.md
@@ -32,19 +32,21 @@ To avoid conflicting IP addresses between the private networks, you must have pr
 
 ### Connections
 
-The connections (ports) that are used between ScalarDL Ledger, ScalarDL Auditor, and the client by default are the following. You must allow these connections between each private network. Note that if you change the listening port of ScalarDL in a configuration file ([ledger|auditor].properties) from default, you must allow the connections using the port you configured.
+The default network ports for connecting ScalarDL Ledger, ScalarDL Auditor, and the application (client) by default are as follows. You must allow these connections between each private network.
 
-* Scalar DL Ledger
-    * 50051/TCP (Accept the requests from a client and Auditor)
-    * 50052/TCP (Accept the privileged requests from a client and Auditor)
-* Scalar DL Auditor
-    * 40051/TCP (Accept the requests from a client and Ledger)
-    * 40052/TCP (Accept the privileged requests from a client and Ledger)
-* Scalar Envoy (Used with Scalar DL Ledger and Scalar DL Auditor)
-    * 50051/TCP (Load balancing for Scalar DL Ledger)
-    * 50052/TCP (Load balancing for Scalar DL Ledger)
-    * 40051/TCP (Load balancing for Scalar DL Auditor)
-    * 40052/TCP (Load balancing for Scalar DL Auditor)
+* **ScalarDL Ledger**
+    * **50051/TCP:** Accept requests from an application (client) and ScalarDL Auditor via Scalar Envoy.
+    * **50052/TCP:** Accept privileged requests from an application (client) and ScalarDL Auditor via Scalar Envoy.
+* **ScalarDL Auditor**
+    * **40051/TCP:** Accept requests from an application (client) and ScalarDL Ledger via Scalar Envoy.
+    * **40052/TCP:** Accept privileged requests from an application (client) and ScalarDL Ledger via Scalar Envoy.
+* **Scalar Envoy** (used with ScalarDL Ledger and ScalarDL Auditor)
+    * **50051/TCP:** Accept requests for ScalarDL Ledger from an application (client) and ScalarDL Auditor.
+    * **50052/TCP:** Accept privileged requests for ScalarDL Ledger from an application (client) and ScalarDL Auditor.
+    * **40051/TCP:** Accept requests for ScalarDL Auditor from an application (client) and ScalarDL Ledger.
+    * **40052/TCP:** Accept privileged requests for ScalarDL Auditor from an application (client) and ScalarDL Ledger.
+
+Note that, if you change the listening port for ScalarDL in the configuration file (ledger.properties or auditor.properties) from the default, you must allow the connections by using the port that you configured.
 
 Private-network peering
 

--- a/docs/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/NetworkPeeringForScalarDLAuditor.md
@@ -38,7 +38,9 @@ The default network ports for connecting ScalarDL Ledger, ScalarDL Auditor, and 
 
 Note that, if you change the listening port for ScalarDL in the configuration file (ledger.properties or auditor.properties) from the default, you must allow the connections by using the port that you configured.
 
-Private-network peering
+## Private-network peering
+
+For details on how to connect private networks in each cloud, see official documents.
 
 ### Amazon VPC peering
 

--- a/docs/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/NetworkPeeringForScalarDLAuditor.md
@@ -2,19 +2,9 @@
 
 This document explains how to connect multiple private networks for ScalarDL Auditor mode to perform network peering. For ScalarDL Auditor mode to work properly, you must connect ScalarDL Ledger to ScalarDL Auditor.
 
-## Private networks to connect
+## What network you must connect
 
-Depending on your application (client) deployment, you must connect multiple private networks.
-
-### Connect two private networks
-
-If you deploy your application (client) on the same private network as ScalarDL Ledger or ScalarDL Auditor, you must connect two private networks.
-
-* [ScalarDL Ledger network] <-> [ScalarDL Auditor network]
-
-### Connect three private networks
-
-If you deploy your application (client) on a separate private network away from ScalarDL Ledger or ScalarDL Auditor, you must connect three private networks.
+To make ScalarDL Auditor mode (Byzantine fault detection) work properly, you must connect three private networks.
 
 * [ScalarDL Ledger network] <-> [ScalarDL Auditor network]
 * [ScalarDL Ledger network] <-> [application (client) network]
@@ -57,4 +47,3 @@ For details on how to peer virtual private clouds (VPCs) in an Amazon Web Servic
 ### Azure VNet peering
 
 For details on how to peer virtual networks in an Azure environment, see the official documentation from Microsoft at [Virtual network peering](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-peering-overview).
-

--- a/docs/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/NetworkPeeringForScalarDLAuditor.md
@@ -1,0 +1,62 @@
+# Create network peering for Scalar DL Auditor mode
+
+This document explains how to connect several private networks for ScalarDL Auditor mode. To make ScalarDL Auditor mode work properly, ScalarDL Ledger and ScalarDL Auditor need to connect with each other. 
+
+## Private network you must connect
+
+Depending on your application (client) deployment, you must connect several private networks.
+
+### Connect two private networks
+
+If you deploy your application on the same private network as ScalarDL Ledger or ScalarDL Auditor, you must connect two private networks.
+
+* [ScalarDL Ledger network] <-> [ScalarDL Auditor network]
+
+### Connect three private networks
+
+If you deploy your application (client) on another private network than ScalarDL Ledger or ScalarDL Auditor, you must connect three private networks.
+
+* [ScalarDL Ledger network] <-> [ScalarDL Auditor network]
+* [ScalarDL Ledger network] <-> [Application (client) network]
+* [ScalarDL Auditor network] <-> [Application (client) network]
+
+## Network requirements
+
+### IP address ranges
+
+To avoid conflicting IP addresses between several private networks, you must create several private networks with different IP address ranges.
+
+* Example
+    * Private network for ScalarDL Ledger -> 10.1.0.0/16
+    * Private network for ScalarDL Auditor -> 10.2.0.0/16
+    * Private network for application (client) -> 10.3.0.0/16
+
+### Connections
+
+The connections (ports) that are used between ScalarDL Ledger, ScalarDL Auditor, and the client by default are the following. You must allow these connections between each private network. Note that if you change the listening port of ScalarDL in a configuration file ([ledger|auditor].properties) from default, you must allow the connections using the port you configured.
+
+* Scalar DL Ledger
+    * 50051/TCP (Accept the requests from a client and Auditor)
+    * 50052/TCP (Accept the privileged requests from a client and Auditor)
+* Scalar DL Auditor
+    * 40051/TCP (Accept the requests from a client and Ledger)
+    * 40052/TCP (Accept the privileged requests from a client and Ledger)
+* Scalar Envoy (Used with Scalar DL Ledger and Scalar DL Auditor)
+    * 50051/TCP (Load balancing for Scalar DL Ledger)
+    * 50052/TCP (Load balancing for Scalar DL Ledger)
+    * 40051/TCP (Load balancing for Scalar DL Auditor)
+    * 40052/TCP (Load balancing for Scalar DL Auditor)
+
+## How to peer the private networks
+
+### AWS (VPC peering)
+
+Please refer to the following official document for more details on how to peer the VPCs in the AWS environment.
+
+* [Create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html)
+
+### Azure (Virtual network peering)
+
+Please refer to the following official document for more details on how to peer the VNets in the Azure environment.
+
+* [Virtual network peering](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-peering-overview)

--- a/docs/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/NetworkPeeringForScalarDLAuditor.md
@@ -1,4 +1,4 @@
-# Configure Scalar DL Auditor mode for network peering
+# Configure ScalarDL Auditor mode for network peering
 
 This document explains how to connect multiple private networks for ScalarDL Auditor mode to perform network peering. For ScalarDL Auditor mode to work properly, you must connect ScalarDL Ledger to ScalarDL Auditor.
 


### PR DESCRIPTION
This PR adds a new document that describes how to connect several private networks for ScalarDL Auditor mode. Since it is recommended to deploy Ledger and Auditor with different administrative domains, we must connect several private networks in the production environment.

Please take a look!