### PR TITLE
Update sample custom values file to use a new way

### DIFF
--- a/conf/scalardb-custom-values.yaml
+++ b/conf/scalardb-custom-values.yaml
@@ -56,24 +56,31 @@ envoy:
 
 scalardb:
   replicaCount: 3
+
   storageConfiguration:
-
-    #
-    # Cosmos DB
-    #
-    # contactPoints: <Cosmos DB account endpoint>
-    # password: <Cosmos DB account primary master key>
-    # storage: cosmos
-
-    #
-    # DynamoDB
-    #
-    # contactPoints: <REGION>
-    # username: <AWS_ACCESS_KEY_ID>
-    # password: <AWS_ACCESS_SECRET_KEY>
-    # storage: dynamo
-
     dbLogLevel: INFO
+
+  databaseProperties: |
+    # # Cosmo DB for NoSQL
+    # # The Cosmos DB for NoSQL URI
+    # scalar.db.contact_points=<COSMOS_DB_FOR_NOSQL_URI>
+    #
+    # # The Cosmos DB for NoSQL key
+    # scalar.db.password=<COSMOS_DB_FOR_NOSQL_KEY>
+    #
+    # # Cosmos DB for NoSQL storage implementation
+    # scalar.db.storage=cosmos
+
+    # # DynamoDB
+    # # The AWS region
+    # scalar.db.contact_points=<REGION>
+    #
+    # # The AWS access key ID and secret access key
+    # scalar.db.username=<ACCESS_KEY_ID>
+    # scalar.db.password=<SECRET_ACCESS_KEY>
+    #
+    # # DynamoDB storage implementation
+    # scalar.db.storage=dynamo
 
   serviceMonitor:
     enabled: false

--- a/conf/scalardl-audit-custom-values.yaml
+++ b/conf/scalardl-audit-custom-values.yaml
@@ -62,23 +62,42 @@ auditor:
 
   scalarAuditorConfiguration:
 
+  auditorProperties: |
+    # # Cosmo DB for NoSQL
+    # # The Cosmos DB for NoSQL URI
+    # scalar.db.contact_points=<COSMOS_DB_FOR_NOSQL_URI>
     #
-    # Cosmos DB
+    # # The Cosmos DB for NoSQL key
+    # scalar.db.password=<COSMOS_DB_FOR_NOSQL_KEY>
     #
-    # dbContactPoints: <Cosmos DB account endpoint>
-    # dbPassword: <Cosmos DB account primary master key>
-    # dbStorage: cosmos
+    # # Cosmos DB for NoSQL storage implementation
+    # scalar.db.storage=cosmos
 
+    # # DynamoDB
+    # # The AWS region
+    # scalar.db.contact_points=<REGION>
     #
-    # DynamoDB
+    # # The AWS access key ID and secret access key
+    # scalar.db.username=<ACCESS_KEY_ID>
+    # scalar.db.password=<SECRET_ACCESS_KEY>
     #
-    # dbStorage: dynamo
-    # dbContactPoints: <REGION>
-    # dbUsername: <AWS_ACCESS_KEY_ID>
-    # dbPassword: <AWS_ACCESS_SECRET_KEY>
+    # # DynamoDB storage implementation
+    # scalar.db.storage=dynamo
 
-    # To use Auditor
-    # auditorLedgerHost: <the service endpoint of ledger-side envoy>
+    # # Auditor configurations
+    # scalar.dl.auditor.ledger.host=<Host name to access ScalarDL Ledger pods>
+    # scalar.dl.auditor.private_key_path=/keys/private-key
+    # scalar.dl.auditor.cert_path=/keys/certificate
+
+  extraVolumes:
+    - name: auditor-keys
+      secret:
+        secretName: auditor-keys
+
+  extraVolumeMounts:
+    - name: auditor-keys
+      mountPath: /keys
+      readOnly: true
 
   prometheusRule:
     enabled: false

--- a/conf/scalardl-custom-values.yaml
+++ b/conf/scalardl-custom-values.yaml
@@ -60,26 +60,42 @@ ledger:
   imagePullSecrets:
     - name: reg-docker-secrets
 
-  scalarLedgerConfiguration:
+  ledgerProperties: |
+    # # Cosmo DB for NoSQL
+    # # The Cosmos DB for NoSQL URI
+    # scalar.db.contact_points=<COSMOS_DB_FOR_NOSQL_URI>
+    #
+    # # The Cosmos DB for NoSQL key
+    # scalar.db.password=<COSMOS_DB_FOR_NOSQL_KEY>
+    #
+    # # Cosmos DB for NoSQL storage implementation
+    # scalar.db.storage=cosmos
 
+    # # DynamoDB
+    # # The AWS region
+    # scalar.db.contact_points=<REGION>
     #
-    # Cosmos DB
+    # # The AWS access key ID and secret access key
+    # scalar.db.username=<ACCESS_KEY_ID>
+    # scalar.db.password=<SECRET_ACCESS_KEY>
     #
-    # dbContactPoints: <Cosmos DB account endpoint>
-    # dbPassword: <Cosmos DB account primary master key>
-    # dbStorage: cosmos
+    # # DynamoDB storage implementation
+    # scalar.db.storage=dynamo
 
-    #
-    # DynamoDB
-    #
-    # dbStorage: dynamo
-    # dbContactPoints: <REGION>
-    # dbUsername: <AWS_ACCESS_KEY_ID>
-    # dbPassword: <AWS_ACCESS_SECRET_KEY>
+    # # Ledger configurations to use Auditor
+    # scalar.dl.ledger.proof.enabled=true
+    # scalar.dl.ledger.auditor.enabled=true
+    # scalar.dl.ledger.proof.private_key_path=/keys/private-key
 
-    # To use Auditor
-    # ledgerProofEnabled: true
-    # ledgerAuditorEnabled: true
+  extraVolumes:
+    - name: ledger-keys
+      secret:
+        secretName: ledger-keys
+
+  extraVolumeMounts:
+    - name: ledger-keys
+      mountPath: /keys
+      readOnly: true
 
   prometheusRule:
     enabled: false


### PR DESCRIPTION
This PR updates the sample custom values files.
The current sample custom values files are using the old way to configure `*.properties`.
So, I updated the old way to the following new way.

* Using `scalardb.databaseProperties`
* Using `ledger.ledgerProperties`
* Using `auditor.auditorProperties`

Please take a look!