### PR TITLE
Support pay as you go scalardl in aws marketplace

### DIFF
--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -2,7 +2,7 @@
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are available in the AWS Marketplace as container images. This guide explains how to install Scalar products through the AWS Marketplace.
 
-Note that some Scalar products are licensed under commercial licenses, and the AWS Marketplace provides them as Pay-As-You-Go and BYOL (Bring Your Own License). If you select Pay-As-You-Go, AWS charges you our product license fee. If you select BYOL, please make sure you have appropriate licenses.
+Note that some Scalar products are available under commercial licenses, and the AWS Marketplace provides those products as pay-as-you-go pricing or a Bring Your Own License (BYOL) option. If you select pay-as-you-go pricing, AWS will charge you our product license fee based on your usage. If you select BYOL, please make sure you have the appropriate license for the product.
 
 ## Subscribe to Scalar products from AWS Marketplace
 

--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -2,7 +2,7 @@
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are provided in AWS Marketplace as Container Image. This guide explains how to install Scalar products through AWS Marketplace.
 
-Note that some Scalar products are licensed under commercial licenses, and the AWS Marketplace provides them as Pay-As-You-Go and BYOL (Bring Your Own License). If you select Pay-As-You-Go, AWS charges you our product license fee. If you choose BYOL, please make sure you have appropriate licenses.
+Note that some Scalar products are licensed under commercial licenses, and the AWS Marketplace provides them as Pay-As-You-Go and BYOL (Bring Your Own License). If you select Pay-As-You-Go, AWS charges you our product license fee. If you select BYOL, please make sure you have appropriate licenses.
 
 ## Subscribe to Scalar products from AWS Marketplace
 

--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -1,6 +1,6 @@
 # How to install Scalar products through AWS Marketplace
 
-Scalar products (ScalarDB, ScalarDL, and their tools) are provided in AWS Marketplace as Container Image. This guide explains how to install Scalar products through AWS Marketplace.
+Scalar products (ScalarDB, ScalarDL, and their tools) are available in the AWS Marketplace as container images. This guide explains how to install Scalar products through the AWS Marketplace.
 
 Note that some Scalar products are licensed under commercial licenses, and the AWS Marketplace provides them as Pay-As-You-Go and BYOL (Bring Your Own License). If you select Pay-As-You-Go, AWS charges you our product license fee. If you select BYOL, please make sure you have appropriate licenses.
 
@@ -24,7 +24,7 @@ Note that some Scalar products are licensed under commercial licenses, and the A
 
 ## **[Pay-As-You-Go]** Deploy containers on EKS (Amazon Elastic Kubernetes Service) from AWS Marketplace using Scalar Helm Charts
 
-If you subscribe to Scalar products in AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of AWS Marketplace. This section explains how to deploy Pay-As-You-Go Scalar products on your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
+By subscribing to Scalar products in the AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of the AWS Marketplace. This section explains how to deploy Scalar products with pay-as-you-go pricing in your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
 
 1. Create an OIDC provider.
 
@@ -53,7 +53,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.
 
-   You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value of `[].serviceAccount.serviceAccountName` and set `true` to `[].serviceAccount.automountServiceAccountToken`.
+   You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
@@ -91,7 +91,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
             version: "3.8.0"
         ```
 
-1. Deploy the Scalar products using the Helm Chart with the above custom values files.
+1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
    * ScalarDL Examples
       * ScalarDL Ledger
         ```console
@@ -112,7 +112,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
 
 ## **[BYOL]** Deploy containers on EKS (Amazon Elastic Kubernetes Service) from AWS Marketplace using Scalar Helm Charts
 
-If you subscribe to Scalar products in AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of AWS Marketplace. This section explains how to deploy BYOL Scalar products on your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
+By subscribing to Scalar products in the AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of the AWS Marketplace. This section explains how to deploy Scalar products with the BYOL option in your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  

--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -51,8 +51,10 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
        --override-existing-serviceaccounts
    ```
 
-1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
+1. Update the custom values file of the Helm Chart of a Scalar product you want to install.
+
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value of `[].serviceAccount.serviceAccountName` and set `true` to `[].serviceAccount.automountServiceAccountToken`.
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml

--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -1,15 +1,17 @@
 # How to install Scalar products through AWS Marketplace
 
-Scalar products (Scalar DB, Scalar DL, and their tools) are provided in AWS Marketplace as Container Image. This guide explains how to install Scalar products through AWS Marketplace.
+Scalar products (ScalarDB, ScalarDL, and their tools) are provided in AWS Marketplace as Container Image. This guide explains how to install Scalar products through AWS Marketplace.
 
-Note that some Scalar products are licensed under commercial licenses, and the AWS Marketplace provides them as BYOL (Bring Your Own License). Please make sure you have appropriate licenses.
+Note that some Scalar products are licensed under commercial licenses, and the AWS Marketplace provides them as Pay-As-You-Go and BYOL (Bring Your Own License). If you select Pay-As-You-Go, AWS charges you our product license fee. If you choose BYOL, please make sure you have appropriate licenses.
 
 ## Subscribe to Scalar products from AWS Marketplace
 
 1. Access to the AWS Marketplace.
-   * [Scalar DB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
-   * [Scalar DL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
-   * [Scalar DL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
+   * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
+   * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
+   * [ScalarDB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
+   * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
+   * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
 
 1. Select **Continue to Subscribe**.
 
@@ -20,14 +22,100 @@ Note that some Scalar products are licensed under commercial licenses, and the A
    It takes some time. When it's done, you can see the current date in the **Effective date** column.
    Also, you can see our products on the [Manage subscriptions](https://us-east-1.console.aws.amazon.com/marketplace/home#/subscriptions) page of AWS Console.
 
+## **[Pay-As-You-Go]** Deploy containers on EKS (Amazon Elastic Kubernetes Service) from AWS Marketplace using Scalar Helm Charts
+
+If you subscribe to Scalar products in AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of AWS Marketplace. This section explains how to deploy Pay-As-You-Go Scalar products on your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
+
+1. Create an OIDC provider.
+
+   You must create an identity and access management (IAM) OpenID Connect (OIDC) provider to run the AWS Marketplace Metering Service from ScalarDL pods.
+
+   ```console
+   eksctl utils associate-iam-oidc-provider --region <REGION> --cluster <EKS_CLUSTER_NAME> --approve
+   ```
+
+   For details, see [Creating an IAM OIDC provider for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+
+1. Create a service account.
+
+   To allow your pods to run the AWS Marketplace Metering Service, you can use [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+
+   ```console
+   eksctl create iamserviceaccount \
+       --name <SERVICE_ACCOUNT_NAME> \
+       --namespace <NAMESPACE> \
+       --region <REGION> \
+       --cluster <EKS_CLUSTER_NAME> \
+       --attach-policy-arn arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess \
+       --approve \
+       --override-existing-serviceaccounts
+   ```
+
+1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
+   You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value of `[].serviceAccount.serviceAccountName` and set `true` to `[].serviceAccount.automountServiceAccountToken`.
+   * ScalarDL Examples
+      * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+        ```yaml
+        ledger:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-ledger-aws-payg"
+            version: "3.8.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+      * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+        ```yaml
+        auditor:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-auditor-aws-payg"
+            version: "3.8.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+      * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+        ```yaml
+        schemaLoading:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
+            version: "3.8.0"
+        ```
+      * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+        ```yaml
+        schemaLoading:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-auditor-aws-payg"
+            version: "3.8.0"
+        ```
+
+1. Deploy the Scalar products using the Helm Chart with the above custom values files.
+   * ScalarDL Examples
+      * ScalarDL Ledger
+        ```console
+        helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
+        ```
+      * ScalarDL Auditor
+        ```console
+        helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
+        ```
+      * ScalarDL Schema Loader (Ledger)
+        ```console
+        helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
+        ```
+      * ScalarDL Schema Loader (Auditor)
+        ```console
+        helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
+        ```
+
 ## **[BYOL]** Deploy containers on EKS (Amazon Elastic Kubernetes Service) from AWS Marketplace using Scalar Helm Charts
 
-If you subscribe to Scalar products in AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of AWS Marketplace. This section explains how to deploy Scalar products on your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
+If you subscribe to Scalar products in AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of AWS Marketplace. This section explains how to deploy BYOL Scalar products on your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
-   * Scalar DB Examples
-      * Scalar DB Server (scalardb-custom-values.yaml)
+   * ScalarDB Examples
+      * ScalarDB Server (scalardb-custom-values.yaml)
         ```yaml
         envoy:
           image:
@@ -41,14 +129,14 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
             tag: "3.5.2"
         ```
-      * Scalar DB GraphQL Server (scalardb-graphql-custom-values.yaml)
+      * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
           tag: "3.6.0"
         ```
-   * Scalar DL Examples
-      * Scalar DL Ledger (scalardl-ledger-custom-values.yaml)
+   * ScalarDL Examples
+      * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml
         envoy:
           image:
@@ -62,7 +150,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
             version: "3.4.1"
         ```
-      * Scalar DL Auditor (scalardl-auditor-custom-values.yaml)
+      * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
         ```yaml
         envoy:
           image:
@@ -76,14 +164,14 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
             version: "3.4.1"
         ```
-      * Scalar DL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+      * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
             version: "3.4.1"
         ```
-      * Scalar DL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+      * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
         ```yaml
         schemaLoading:
           image:
@@ -92,29 +180,29 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
         ```
 
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
-   * Scalar DB Examples
-      * Scalar DB Server
+   * ScalarDB Examples
+      * ScalarDB Server
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
-      * Scalar DB GraphQL Server
+      * ScalarDB GraphQL Server
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
-   * Scalar DL Examples
-      * Scalar DL Ledger
+   * ScalarDL Examples
+      * ScalarDL Ledger
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
-      * Scalar DL Auditor
+      * ScalarDL Auditor
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
-      * Scalar DL Schema Loader (Ledger)
+      * ScalarDL Schema Loader (Ledger)
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
-      * Scalar DL Schema Loader (Auditor)
+      * ScalarDL Schema Loader (Auditor)
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -136,8 +224,8 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
-   * Scalar DB Examples
-       * Scalar DB Server (scalardb-custom-values.yaml)
+   * ScalarDB Examples
+       * ScalarDB Server (scalardb-custom-values.yaml)
          ```yaml
          envoy:
            image:
@@ -155,7 +243,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
-       * Scalar DB GraphQL Server (scalardb-graphql-custom-values.yaml)
+       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
@@ -163,8 +251,8 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
-   * Scalar DL Examples
-       * Scalar DL Ledger (scalardl-ledger-custom-values.yaml)
+   * ScalarDL Examples
+       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
          ```yaml
          envoy:
            image:
@@ -182,7 +270,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
-       * Scalar DL Auditor (scalardl-auditor-custom-values.yaml)
+       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
          ```yaml
          envoy:
            image:
@@ -200,7 +288,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
-       * Scalar DL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
          ```yaml
          schemaLoading:
            image:
@@ -209,7 +297,7 @@ If you subscribe to Scalar products in AWS Marketplace, you can pull the contain
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
-       * Scalar DL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
          ```yaml
          schemaLoading:
            image:


### PR DESCRIPTION
**Note: We have to merge this PR after we publish pay-as-you-go ScalarDL on AWS Marketplace. We are working on it now.**

This PR adds the `how to deploy pay-as-you-go ScalarDL` section in the AWS Marketplace guide.

Also, I fixed product names in this document (`Scalar DB` -> `ScalarDB` / `Scalar DL` -> `ScalarDL`).

Please take a look!