### PR TITLE
Fix link name in deployment guide

### DIFF
--- a/docs/CreateAKSClusterForScalarDB.md
+++ b/docs/CreateAKSClusterForScalarDB.md
@@ -1,4 +1,4 @@
-# A guideline for creating an AKS cluster for ScalarDB Server
+# Guidelines for creating an AKS cluster for ScalarDB Server
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an AKS cluster, see [Deploy ScalarDB Server on AKS](./ManualDeploymentGuideScalarDBServerOnAKS.md).
 

--- a/docs/CreateAKSClusterForScalarDB.md
+++ b/docs/CreateAKSClusterForScalarDB.md
@@ -1,4 +1,4 @@
-# Guidelines for creating an AKS cluster for ScalarDB Server
+# A guideline for creating an AKS cluster for ScalarDB Server
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an AKS cluster, see [Deploy ScalarDB Server on AKS](./ManualDeploymentGuideScalarDBServerOnAKS.md).
 

--- a/docs/CreateAKSClusterForScalarDL.md
+++ b/docs/CreateAKSClusterForScalarDL.md
@@ -1,4 +1,4 @@
-# Guidelines for creating an AKS cluster for ScalarDL Ledger
+# A guideline for creating an AKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an AKS cluster, see [Deploy ScalarDL Ledger on AKS](./ManualDeploymentGuideScalarDLOnAKS.md).
 

--- a/docs/CreateAKSClusterForScalarDL.md
+++ b/docs/CreateAKSClusterForScalarDL.md
@@ -1,4 +1,4 @@
-# A guideline for creating an AKS cluster for ScalarDL Ledger
+# Guidelines for creating an AKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an AKS cluster, see [Deploy ScalarDL Ledger on AKS](./ManualDeploymentGuideScalarDLOnAKS.md).
 

--- a/docs/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/CreateAKSClusterForScalarDLAuditor.md
@@ -1,4 +1,4 @@
-# Guidelines for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor
+# A guideline for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an AKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on AKS](./ManualDeploymentGuideScalarDLAuditorOnAKS.md).
 

--- a/docs/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/CreateAKSClusterForScalarDLAuditor.md
@@ -1,4 +1,4 @@
-# A guideline for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor
+# Guidelines for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an AKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on AKS](./ManualDeploymentGuideScalarDLAuditorOnAKS.md).
 

--- a/docs/CreateAKSClusterForScalarProducts.md
+++ b/docs/CreateAKSClusterForScalarProducts.md
@@ -1,10 +1,10 @@
-# Guidelines for creating an AKS cluster for Scalar products
+# A guideline for creating an AKS cluster for Scalar products
 
 To create an Azure Kubernetes Service (AKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an AKS cluster for ScalarDB Server](./CreateAKSClusterForScalarDB.md)
-* [Guidelines for creating an AKS cluster for ScalarDL Ledger](./CreateAKSClusterForScalarDL.md)
-* [Guidelines for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateAKSClusterForScalarDLAuditor.md)
+* [A guideline for creating an AKS cluster for ScalarDB Server](./CreateAKSClusterForScalarDB.md)
+* [A guideline for creating an AKS cluster for ScalarDL Ledger](./CreateAKSClusterForScalarDL.md)
+* [A guideline for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateAKSClusterForScalarDLAuditor.md)
 
 To deploy Scalar products on AKS, refer to the following:
 

--- a/docs/CreateAKSClusterForScalarProducts.md
+++ b/docs/CreateAKSClusterForScalarProducts.md
@@ -1,10 +1,10 @@
-# A guideline for creating an AKS cluster for Scalar products
+# Guidelines for creating an AKS cluster for Scalar products
 
 To create an Azure Kubernetes Service (AKS) cluster for Scalar products, refer to the following:
 
-* [A guideline for creating an AKS cluster for ScalarDB Server](./CreateAKSClusterForScalarDB.md)
-* [A guideline for creating an AKS cluster for ScalarDL Ledger](./CreateAKSClusterForScalarDL.md)
-* [A guideline for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateAKSClusterForScalarDLAuditor.md)
+* [Guidelines for creating an AKS cluster for ScalarDB Server](./CreateAKSClusterForScalarDB.md)
+* [Guidelines for creating an AKS cluster for ScalarDL Ledger](./CreateAKSClusterForScalarDL.md)
+* [Guidelines for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateAKSClusterForScalarDLAuditor.md)
 
 To deploy Scalar products on AKS, refer to the following:
 

--- a/docs/CreateEKSClusterForScalarDB.md
+++ b/docs/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,4 @@
-# A guideline for creating an EKS cluster for ScalarDB Server
+# Guidelines for creating an EKS cluster for ScalarDB Server
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 

--- a/docs/CreateEKSClusterForScalarDB.md
+++ b/docs/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,4 @@
-# Guidelines for creating an EKS cluster for ScalarDB Server
+# A guideline for creating an EKS cluster for ScalarDB Server
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 

--- a/docs/CreateEKSClusterForScalarDL.md
+++ b/docs/CreateEKSClusterForScalarDL.md
@@ -1,4 +1,4 @@
-# Guidelines for creating an EKS cluster for ScalarDL Ledger
+# A guideline for creating an EKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an EKS cluster, see [Deploy ScalarDL Ledger on Amazon EKS](./ManualDeploymentGuideScalarDLOnEKS.md).
 

--- a/docs/CreateEKSClusterForScalarDL.md
+++ b/docs/CreateEKSClusterForScalarDL.md
@@ -1,4 +1,4 @@
-# A guideline for creating an EKS cluster for ScalarDL Ledger
+# Guidelines for creating an EKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an EKS cluster, see [Deploy ScalarDL Ledger on Amazon EKS](./ManualDeploymentGuideScalarDLOnEKS.md).
 

--- a/docs/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/CreateEKSClusterForScalarDLAuditor.md
@@ -1,4 +1,4 @@
-# Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor
+# A guideline for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an EKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on Amazon EKS](./ManualDeploymentGuideScalarDLAuditorOnEKS.md).
 

--- a/docs/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/CreateEKSClusterForScalarDLAuditor.md
@@ -1,4 +1,4 @@
-# A guideline for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor
+# Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an EKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on Amazon EKS](./ManualDeploymentGuideScalarDLAuditorOnEKS.md).
 

--- a/docs/CreateEKSClusterForScalarProducts.md
+++ b/docs/CreateEKSClusterForScalarProducts.md
@@ -1,10 +1,10 @@
-# A guideline for creating an Amazon EKS cluster for Scalar products
+# Guidelines for creating an Amazon EKS cluster for Scalar products
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [A guideline for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
-* [A guideline for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
-* [A guideline for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
+* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
+* [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 
 To deploy Scalar products on Amazon EKS, refer to the following:
 

--- a/docs/CreateEKSClusterForScalarProducts.md
+++ b/docs/CreateEKSClusterForScalarProducts.md
@@ -1,10 +1,10 @@
-# Guidelines for creating an Amazon EKS cluster for Scalar products
+# A guideline for creating an Amazon EKS cluster for Scalar products
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
-* [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
-* [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
+* [A guideline for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [A guideline for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
+* [A guideline for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 
 To deploy Scalar products on Amazon EKS, refer to the following:
 

--- a/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -18,7 +18,7 @@ You must get the ScalarDB Server container image by visiting [Azure Marketplace]
 
 ## Step 2. Create an AKS cluster
 
-You must create an AKS cluster for the ScalarDB Server deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDB Server deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDB Server
 

--- a/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -18,7 +18,7 @@ You must get the ScalarDB Server container image by visiting [Azure Marketplace]
 
 ## Step 2. Create an AKS cluster
 
-You must create an AKS cluster for the ScalarDB Server deployment. For details, see [Create an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDB Server deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDB Server
 

--- a/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -18,7 +18,7 @@ You must get the ScalarDB Server container image by visiting [Azure Marketplace]
 
 ## Step 2. Create an AKS cluster
 
-You must create an AKS cluster for the ScalarDB Server deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDB Server deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDB Server
 

--- a/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
@@ -18,7 +18,7 @@ You must get the ScalarDB Server container image by visiting [AWS Marketplace](h
 
 ## Step 2. Create an EKS cluster
 
-You must create an EKS cluster for the ScalarDB Server deployment. For details, see [Create an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDB Server deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDB Server
 

--- a/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
@@ -18,7 +18,7 @@ You must get the ScalarDB Server container image by visiting [AWS Marketplace](h
 
 ## Step 2. Create an EKS cluster
 
-You must create an EKS cluster for the ScalarDB Server deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDB Server deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDB Server
 

--- a/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
@@ -18,7 +18,7 @@ You must get the ScalarDB Server container image by visiting [AWS Marketplace](h
 
 ## Step 2. Create an EKS cluster
 
-You must create an EKS cluster for the ScalarDB Server deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDB Server deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDB Server
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
@@ -24,11 +24,11 @@ You must get the ScalarDL Ledger and ScalarDL Auditor container images by visiti
 
 ## Step 2. Create an AKS cluster for ScalarDL Ledger
 
-You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Create an AKS cluster for ScalarDL Auditor
 
-You must also create an AKS cluster for the ScalarDL Auditor deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must also create an AKS cluster for the ScalarDL Auditor deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 4. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
@@ -24,11 +24,11 @@ You must get the ScalarDL Ledger and ScalarDL Auditor container images by visiti
 
 ## Step 2. Create an AKS cluster for ScalarDL Ledger
 
-You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [Create an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Create an AKS cluster for ScalarDL Auditor
 
-You must also create an AKS cluster for the ScalarDL Auditor deployment. For details, see [Create an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must also create an AKS cluster for the ScalarDL Auditor deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 4. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
@@ -24,11 +24,11 @@ You must get the ScalarDL Ledger and ScalarDL Auditor container images by visiti
 
 ## Step 2. Create an AKS cluster for ScalarDL Ledger
 
-You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Create an AKS cluster for ScalarDL Auditor
 
-You must also create an AKS cluster for the ScalarDL Auditor deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must also create an AKS cluster for the ScalarDL Auditor deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 4. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
@@ -24,11 +24,11 @@ You must get the ScalarDL Ledger and ScalarDL Auditor container images from [AWS
 
 ## Step 2. Create an EKS cluster for ScalarDL Ledger
 
-You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Create an EKS cluster for ScalarDL Auditor
 
-You must also create an EKS cluster for the ScalarDL Auditor deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must also create an EKS cluster for the ScalarDL Auditor deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 4. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
@@ -24,11 +24,11 @@ You must get the ScalarDL Ledger and ScalarDL Auditor container images from [AWS
 
 ## Step 2. Create an EKS cluster for ScalarDL Ledger
 
-You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [Create an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Create an EKS cluster for ScalarDL Auditor
 
-You must also create an EKS cluster for the ScalarDL Auditor deployment. For details, see [Create an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must also create an EKS cluster for the ScalarDL Auditor deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 4. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
@@ -24,11 +24,11 @@ You must get the ScalarDL Ledger and ScalarDL Auditor container images from [AWS
 
 ## Step 2. Create an EKS cluster for ScalarDL Ledger
 
-You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Create an EKS cluster for ScalarDL Auditor
 
-You must also create an EKS cluster for the ScalarDL Auditor deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must also create an EKS cluster for the ScalarDL Auditor deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 4. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAKS.md
@@ -12,7 +12,7 @@ You must get the ScalarDL Ledger container image from [Azure Marketplace](https:
 
 ## Step 2. Create an AKS cluster
 
-You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAKS.md
@@ -12,7 +12,7 @@ You must get the ScalarDL Ledger container image from [Azure Marketplace](https:
 
 ## Step 2. Create an AKS cluster
 
-You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [Create an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAKS.md
@@ -12,7 +12,7 @@ You must get the ScalarDL Ledger container image from [Azure Marketplace](https:
 
 ## Step 2. Create an AKS cluster
 
-You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
+You must create an AKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an AKS cluster for Scalar products](./CreateAKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnEKS.md
@@ -12,7 +12,7 @@ You must get the ScalarDL Ledger container image from [AWS Marketplace](https://
 
 ## Step 2. Create an EKS cluster
 
-You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnEKS.md
@@ -12,7 +12,7 @@ You must get the ScalarDL Ledger container image from [AWS Marketplace](https://
 
 ## Step 2. Create an EKS cluster
 
-You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [Guidelines for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDL Ledger
 

--- a/docs/ManualDeploymentGuideScalarDLOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnEKS.md
@@ -12,7 +12,7 @@ You must get the ScalarDL Ledger container image from [AWS Marketplace](https://
 
 ## Step 2. Create an EKS cluster
 
-You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [Create an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
+You must create an EKS cluster for the ScalarDL Ledger deployment. For details, see [A guideline for creating an Amazon EKS cluster for Scalar products](./CreateEKSClusterForScalarProducts.md).
 
 ## Step 3. Set up a database for ScalarDL Ledger
 


### PR DESCRIPTION
This PR updates the link (document) name in the manual deployment guide based on the https://github.com/scalar-labs/scalar-kubernetes/pull/200#discussion_r1268854512 in another PR.

Please take a look!