### PR TITLE
Fix broken links pointing to deleted ScalarDB "Getting Started" docs

### DIFF
--- a/docs/RestoreDatabase.md
+++ b/docs/RestoreDatabase.md
@@ -87,7 +87,7 @@ When using the PITR feature, Azure Cosmos DB restores data by using another acco
 3. Update **database.properties** for ScalarDB Schema Loader or ScalarDL Schema Loader based on the newly restored account.
 
    ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas by using ScalarDB Schema Loader or ScalarDL Schema Loader. However, the PITR feature in Cosmos DB does not restore stored procedures, so you will need to reinstall the required stored procedures for all tables after restoration. You can reinstall the required stored procedures by using the `--repair-all` option in ScalarDB Schema Loader or ScalarDL Schema Loader.
-   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Getting Started with ScalarDB on Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md).
+   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1).
 
    * **ScalarDL tables:** For details on how to configure the custom values file for ScalarDL Schema Loader, see [Configure a custom values file for ScalarDL Schema Loader](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-schema-loader.md).
 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -17,7 +17,7 @@ scalar.db.storage=dynamo
 
 Please refer to the following document for more details on the properties for DynamoDB.
 
-* [Getting Started with ScalarDB on DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-dynamodb.md)
+* [Configure ScalarDB for DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-2)
 
 ### Required configuration/steps
 
@@ -77,7 +77,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for RDS (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -132,7 +132,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Amazon Aurora (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/SetupDatabaseForAzure.md
+++ b/docs/SetupDatabaseForAzure.md
@@ -16,7 +16,7 @@ scalar.db.storage=cosmos
 
 Please refer to the following document for more details on the properties for Cosmos DB for NoSQL.
 
-* [Getting Started with ScalarDB on Cosmos DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md)
+* [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1)
 
 ### Required configuration/steps
 
@@ -85,7 +85,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for MySQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -149,7 +149,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for PostgreSQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 


### PR DESCRIPTION
## Description

This PR fixes broken links that were a result of reorganizing the ScalarDB "Getting Started" docs in the following PR: https://github.com/scalar-labs/scalardb/pull/990.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/990

## Changes made

- Fixed broken links with working links that point to the appropriate headings in [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).

> **Note**
> 
> In the future, it would be nice to change GitHub links to docs site links. However, this currently seems a bit difficult to do without having branches. I think we should avoid using absolute URLs in this case because we don't want to forcibly point users who are reading earlier versions of docs to the latest version of this doc. If that happens, users are likely to get lost and wonder why they are suddenly on the latest version of the docs.

## Branches this PR applies to

- `master`

## Testing done

Clicked the links to made sure they worked properly.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] The documentation has been updated to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A