### PR TITLE
Remove inappropriate resource information of Envoy

### DIFF
--- a/conf/scalardb-cluster-custom-values-indirect-mode.yaml
+++ b/conf/scalardb-cluster-custom-values-indirect-mode.yaml
@@ -19,14 +19,6 @@ envoy:
       service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
-  resources:
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    limits:
-      cpu: 300m
-      memory: 328Mi
-
   tolerations:
     - effect: NoSchedule
       key: scalar-labs.com/dedicated-node

--- a/conf/scalardb-custom-values.yaml
+++ b/conf/scalardb-custom-values.yaml
@@ -17,14 +17,6 @@ envoy:
       service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
-  resources:
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    limits:
-      cpu: 300m
-      memory: 328Mi
-
   tolerations:
     - effect: NoSchedule
       key: scalar-labs.com/dedicated-node

--- a/conf/scalardl-audit-custom-values.yaml
+++ b/conf/scalardl-audit-custom-values.yaml
@@ -46,14 +46,6 @@ envoy:
                   - envoy
           topologyKey: kubernetes.io/hostname
 
-  resources:
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    limits:
-      cpu: 300m
-      memory: 328Mi
-
 auditor:
   replicaCount: 3
 

--- a/conf/scalardl-custom-values.yaml
+++ b/conf/scalardl-custom-values.yaml
@@ -46,14 +46,6 @@ envoy:
                   - envoy
           topologyKey: kubernetes.io/hostname
 
-  resources:
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    limits:
-      cpu: 300m
-      memory: 328Mi
-
 ledger:
   replicaCount: 3
 

--- a/docs/CreateAKSClusterForScalarDB.md
+++ b/docs/CreateAKSClusterForScalarDB.md
@@ -28,7 +28,7 @@ From the perspective of commercial licenses, resources for one pod running Scala
 In other words, the following components run on one worker node:
 
 * ScalarDB Server pod (2vCPU / 4GB)
-* Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+* Envoy proxy
 * Kubernetes components
 
 With this in mind, you should use a worker node that has 4vCPU / 8GB memory resources. We recommend running only the above components on the worker node for ScalarDB Server. However, if you want to run other pods on the worker node for ScalarDB Server, you should use a worker node that has more than 4vCPU / 8GB memory.

--- a/docs/CreateAKSClusterForScalarDL.md
+++ b/docs/CreateAKSClusterForScalarDL.md
@@ -32,7 +32,7 @@ From the perspective of commercial licenses, resources for one pod running Scala
 In other words, the following components run on one worker node:
 
 * ScalarDL Ledger pod (2vCPU / 4GB)
-* Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+* Envoy proxy
 * Kubernetes components
 
 With this in mind, you should use a worker node that has 4vCPU / 8GB memory resources. We recommend running only the above components on the worker node for ScalarDL Ledger. And remember, for Byzantine fault detection to work properly, you cannot deploy your application pods on the same AKS cluster as the ScalarDL Ledger deployment.

--- a/docs/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/CreateAKSClusterForScalarDLAuditor.md
@@ -39,11 +39,11 @@ In other words, the following components run on one worker node:
 
 * AKS cluster for ScalarDL Ledger
   * ScalarDL Ledger pod (2vCPU / 4GB)
-  * Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+  * Envoy proxy
   * Kubernetes components
 * AKS cluster for ScalarDL Auditor
   * ScalarDL Auditor pod (2vCPU / 4GB)
-  * Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+  * Envoy proxy
   * Kubernetes components
 
 With this in mind, you should use the worker node that has 4vCPU / 8GB memory resources. We recommend running only the above components on the worker node for ScalarDL Ledger and ScalarDL Auditor. And remember, for Byzantine fault detection to work properly, you cannot deploy your application pods on the same AKS clusters as the ScalarDL Ledger and ScalarDL Auditor deployments.

--- a/docs/CreateEKSClusterForScalarDB.md
+++ b/docs/CreateEKSClusterForScalarDB.md
@@ -26,7 +26,7 @@ From the perspective of commercial licenses, resources for one pod running Scala
 In other words, the following components run on one worker node:
 
 * ScalarDB Server pod (2vCPU / 4GB)
-* Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+* Envoy proxy
 * Kubernetes components
 
 With this in mind, you should use a worker node that has 4vCPU / 8GB memory resources. We recommend running only the above components on the worker node for ScalarDB Server. However, if you want to run other pods on the worker node for ScalarDB Server, you should use a worker node that has more than 4vCPU / 8GB memory.

--- a/docs/CreateEKSClusterForScalarDBCluster.md
+++ b/docs/CreateEKSClusterForScalarDBCluster.md
@@ -24,7 +24,7 @@ From the perspective of commercial licenses, resources for one pod running Scala
 In other words, the following components run on one worker node:
 
 * ScalarDB Cluster pod (2vCPU / 4GB)
-* Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+* Envoy proxy
 * Kubernetes components
 
 With this in mind, you should use a worker node that has 4vCPU / 8GB memory resources. We recommend running only the above components on the worker node for ScalarDB Cluster. However, if you want to run other pods on the worker node for ScalarDB Cluster, you should use a worker node that has more than 4vCPU / 8GB memory.

--- a/docs/CreateEKSClusterForScalarDL.md
+++ b/docs/CreateEKSClusterForScalarDL.md
@@ -28,7 +28,7 @@ From the perspective of commercial licenses, resources for one pod running Scala
 In other words, the following components run on one worker node:
 
 * ScalarDL Ledger pod (2vCPU / 4GB)
-* Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+* Envoy proxy
 * Kubernetes components
 
 With this in mind, you should use a worker node that has 4vCPU / 8GB memory resources. We recommend running only the above components on the worker node for ScalarDL Ledger. And remember, for Byzantine fault detection to work properly, you cannot deploy your application pods on the same EKS cluster as the ScalarDL Ledger deployment.

--- a/docs/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/CreateEKSClusterForScalarDLAuditor.md
@@ -34,11 +34,11 @@ In other words, the following components run on one worker node:
 
 * Amazon EKS cluster for ScalarDL Ledger
   * ScalarDL Ledger pod (2vCPU / 4GB)
-  * Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+  * Envoy proxy
   * Kubernetes components
 * Amazon EKS cluster for ScalarDL Auditor
   * ScalarDL Auditor pod (2vCPU / 4GB)
-  * Envoy proxy (0.2–0.3 vCPU / 256–328 MB)
+  * Envoy proxy
   * Kubernetes components
 
 With this in mind, you should use the worker node that has 4vCPU / 8GB memory resources. We recommend running only the above components on the worker node for ScalarDL Ledger and ScalarDL Auditor. And remember, for Byzantine fault detection to work properly, you cannot deploy your application pods on the same EKS clusters as the ScalarDL Ledger and ScalarDL Auditor deployments.


### PR DESCRIPTION
At this time, there are some descriptions of resources that Scalar Envoy uses.
However, this information is very old, and we don't have any concrete basis information.
In other words, we cannot use this information for resource estimation.
This information may cause unnecessary confusion.

So, we decided to remove this information.
Please take a look.

FYI: We will create an internal test environment (We call it PSIM in our internal document) that simulates production workload in the future. We will measure resources with some benchmarking workload on that environment in the future.