### PR TITLE
Update recommendations in Marketplace guides

### DIFF
--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -55,7 +55,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.
 
-   You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
+   You need to specify the private container registry (ECR) of the AWS Marketplace as the value for `[].image.repository` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
    * ScalarDB Cluster Examples
      * ScalarDB Cluster Standard Edition (scalardb-cluster-standard-custom-values.yaml)
@@ -63,7 +63,6 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         scalardbCluster:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-standard"
-            tag: "3.10.1"
           serviceAccount:
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
@@ -73,7 +72,6 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
        scalardbCluster:
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-premium"
-           tag: "3.10.1"
           serviceAccount:
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
@@ -84,7 +82,6 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ledger:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-ledger-aws-payg"
-            version: "3.8.1"
           serviceAccount:
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
@@ -94,7 +91,6 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         auditor:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-auditor-aws-payg"
-            version: "3.8.1"
           serviceAccount:
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
@@ -104,14 +100,12 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
-            version: "3.8.0"
         ```
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-auditor-aws-payg"
-            version: "3.8.0"
         ```
 
 1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
@@ -147,79 +141,52 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 By subscribing to Scalar products in the AWS Marketplace, you can pull the container images of Scalar products from the private container registry ([ECR](https://aws.amazon.com/ecr/)) of the AWS Marketplace. This section explains how to deploy Scalar products with the BYOL option in your [EKS](https://aws.amazon.com/eks/) cluster from the private container registry.
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
-   You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
+   You need to specify the private container registry (ECR) of AWS Marketplace as the value of `[].image.repository` in the custom values file.  
    * ScalarDB Examples
-      * ScalarDB Server (scalardb-custom-values.yaml)
+      * [Deprecated] ScalarDB Server (scalardb-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-envoy"
-            version: "1.2.0"
-        
-        ...
-        
         scalardb:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
-            tag: "3.5.2"
         ```
-      * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+      * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
-          tag: "3.6.0"
         ```
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger-envoy"
-            version: "1.2.0"
-        
-        ...
-        
         ledger:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
-            version: "3.4.1"
         ```
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor-envoy"
-            version: "1.2.0"
-        
-        ...
-        
         auditor:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
-            version: "3.4.1"
         ```
       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
-            version: "3.4.1"
         ```
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-auditor"
-            version: "3.4.1"
         ```
 
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
    * ScalarDB Examples
-      * ScalarDB Server
+      * [Deprecated] ScalarDB Server
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
-      * ScalarDB GraphQL Server
+      * [Deprecated] ScalarDB GraphQL Server
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
@@ -256,69 +223,38 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    ```
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
-   You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
+   You need to specify the private container registry (ECR) of AWS Marketplace as the value of `[].image.repository` in the custom values file.  
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
-       * ScalarDB Server (scalardb-custom-values.yaml)
+       * [Deprecated] ScalarDB Server (scalardb-custom-values.yaml)
          ```yaml
-         envoy:
-           image:
-             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-envoy"
-             version: "1.2.0"
-           imagePullSecrets:
-             - name: "reg-ecr-mp-secrets"
-         
-         ...
-         
          scalardb:
            image:
              repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
-             tag: "3.5.2"
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
-       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+       * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
-           tag: "3.6.0"
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
          ```yaml
-         envoy:
-           image:
-             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger-envoy"
-             version: "1.2.0"
-           imagePullSecrets:
-             - name: "reg-ecr-mp-secrets"
-         
-         ...
-         
          ledger:
            image:
              repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
-             version: "3.4.1"
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
          ```yaml
-         envoy:
-           image:
-             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor-envoy"
-             version: "1.2.0"
-           imagePullSecrets:
-             - name: "reg-ecr-mp-secrets"
-         
-         ...
-         
          auditor:
            image:
              repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
-             version: "3.4.1"
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
@@ -327,7 +263,6 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          schemaLoading:
            image:
              repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
-             version: "3.4.1"
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
@@ -336,7 +271,6 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          schemaLoading:
            image:
              repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-auditor"
-             version: "3.4.1"
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```

--- a/docs/AzureMarketplaceGuide.md
+++ b/docs/AzureMarketplaceGuide.md
@@ -33,16 +33,15 @@ Note that **Company** is not required, but please enter it.
    You need several container images to run Scalar products on Kubernetes, but Azure Marketplace copies only one container image at a time. So, you need to subscribe to several software plans (repeat subscribe operation) as needed.
    * Container images that you need are the following.
         * ScalarDB
-            * ScalarDB Server Default (2vCPU, 4GiB Memory)
-            * ScalarDB Server Envoy Proxy
-            * ScalarDB GraphQL Server (optional)
-            * ScalarDB SQL Server (optional)
+            * [Deprecated] ScalarDB Server Default (2vCPU, 4GiB Memory)
+            * [Deprecated] ScalarDB GraphQL Server (optional)
+            * [Deprecated] ScalarDB SQL Server (optional)
+            * [Recommended / coming soon] ScalarDB Cluster
         * ScalarDL
             * ScalarDL Ledger Default (2vCPU, 4GiB Memory)
             * ScalarDL Auditor Default (2vCPU, 4GiB Memory)
                 * The **ScalarDL Auditor** is optional. If you use the **ScalarDL Auditor**, subscribe to it.
             * ScalarDL Schema Loader
-            * ScalarDL Envoy
 
 Now, you can pull the container images of the Scalar products from your private container registry.
 Please refer to the [Azure Container Registry documentation](https://docs.microsoft.com/en-us/azure/container-registry/) for more details about the Azure Container Registry.
@@ -56,72 +55,46 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
      Please specify `--attach-acr` flag with the name of your private container registry. Also, you can configure Azure Container Registry integration for existing AKS clusters using [az aks update](https://docs.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-update) command with `--attach-acr` flag. Please refer to the [Azure Official Document](https://docs.microsoft.com/en-us/azure/aks/cluster-container-registry-integration) for more details.
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
-   You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
+   You need to specify your private container registry as the value of `[].image.repository` in the custom values file.  
    * ScalarDB Examples
-      * ScalarDB Server (scalardb-custom-values.yaml)
+      * [Deprecated] ScalarDB Server (scalardb-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardb-envoy"
-            version: "1.2.0"
-        
-        ...
-        
         scalardb:
           image:
             repository: "example.azurecr.io/scalarinc/scalardb-server"
-            tag: "3.5.2"
         ```
-      * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+      * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
-          tag: "3.6.0"
         ```
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardl-envoy"
-            version: "1.2.0"
-        
-        ...
-        
         ledger:
           image:
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
-            version: "3.4.0"
         ```
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardl-envoy"
-            version: "1.2.0"
-        
-        ...
-        
         auditor:
           image:
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
-            version: "3.4.0"
         ```
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
         ```yaml
         schemaLoading:
           image:
             repository: "example.azurecr.io/scalarinc/scalardl-schema-loader"
-            version: "3.4.0"
         ```
 
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
    * ScalarDB Examples
-      * ScalarDB Server
+      * [Deprecated] ScalarDB Server
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
-      * ScalarDB GraphQL Server
+      * [Deprecated] ScalarDB GraphQL Server
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
@@ -160,69 +133,38 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    ```
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
-   You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
+   You need to specify your private container registry as the value of `[].image.repository` in the custom values file.  
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
-      * ScalarDB Server (scalardb-custom-values.yaml)
+      * [Deprecated]  (scalardb-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardb-envoy"
-            version: "1.2.0"
-          imagePullSecrets:
-            - name: "reg-acr-secrets"
-        
-        ...
-        
         scalardb:
           image:
             repository: "example.azurecr.io/scalarinc/scalardb-server"
-            tag: "3.5.2"
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
-      * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+      * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
-          tag: "3.6.0"
         imagePullSecrets:
           - name: "reg-acr-secrets"
         ```
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardl-envoy"
-            version: "1.2.0"
-          imagePullSecrets:
-            - name: "reg-acr-secrets"
-        
-        ...
-        
         ledger:
           image:
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
-            version: "3.4.0"
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
         ```yaml
-        envoy:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardl-envoy"
-            version: "1.2.0"
-          imagePullSecrets:
-            - name: "reg-acr-secrets"
-        
-        ...
-        
         auditor:
           image:
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
-            version: "3.4.0"
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
@@ -231,7 +173,6 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         schemaLoading:
           image:
             repository: "example.azurecr.io/scalarinc/scalardl-schema-loader"
-            version: "3.4.0"
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```


### PR DESCRIPTION
## Description

We updated our recommendations for production environment. So, I updated marketplace guides based on the new recommendations.

## Related issues and/or PRs

N/A

## Changes made

* Remove `tag` or `version` configuration from custom values file. Now, we recommend to use default values in each Helm Chart.
* Remove `*.image.repository` configuration of Scalar Envoy. Now, we recommend to use the default (public) container repository of [Scalar Envoy](https://github.com/orgs/scalar-labs/packages/container/package/scalar-envoy).
* Mark ScalarDB Server and ScalarDB GraphQL as deprecated.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
