### PR TITLE
Add ScalarDB Cluster (BYOL) in Marketplace guides

### DIFF
--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -9,11 +9,12 @@ Note that some Scalar products are available under commercial licenses, and the 
 1. Access to the AWS Marketplace.
    * [ScalarDB Cluster Standard Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-jx6qxatkxuwm4)
    * [ScalarDB Cluster Premium Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-djqw3zk6dwyk6)
+   * [ScalarDB Cluster (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-alcwrmw6v4cfy)
    * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
    * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
-   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
    * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
    * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
+   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
 
 1. Select **Continue to Subscribe**.
 
@@ -142,18 +143,12 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
    You need to specify the private container registry (ECR) of AWS Marketplace as the value of `[].image.repository` in the custom values file.  
-   * ScalarDB Examples
-      * [Deprecated] ScalarDB Server (scalardb-custom-values.yaml)
-        ```yaml
-        scalardb:
-          image:
-            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
-        ```
-      * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
-        ```yaml
-        image:
-          repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
-        ```
+   * ScalarDB Cluster Examples
+     ```yaml
+     scalardbCluster:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-byol"
+     ```
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml
@@ -181,15 +176,10 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ```
 
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
-   * ScalarDB Examples
-      * [Deprecated] ScalarDB Server
-        ```console
-        helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
-        ```
-      * [Deprecated] ScalarDB GraphQL Server
-        ```console
-        helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
-        ```
+   * ScalarDB Cluster Examples
+     ```console
+     helm install scalardb-cluster scalar-labs/scalardb-cluster -f scalardb-cluster-custom-values.yaml
+     ```
    * ScalarDL Examples
       * ScalarDL Ledger
         ```console
@@ -225,22 +215,14 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
    You need to specify the private container registry (ECR) of AWS Marketplace as the value of `[].image.repository` in the custom values file.  
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
-   * ScalarDB Examples
-       * [Deprecated] ScalarDB Server (scalardb-custom-values.yaml)
-         ```yaml
-         scalardb:
-           image:
-             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
-           imagePullSecrets:
-             - name: "reg-ecr-mp-secrets"
-         ```
-       * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
-         ```yaml
-         image:
-           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
-         imagePullSecrets:
-           - name: "reg-ecr-mp-secrets"
-         ```
+   * ScalarDB Cluster Examples
+     ```yaml
+     scalardbCluster:
+       image:
+         repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-byol"
+       imagePullSecrets:
+         - name: "reg-ecr-mp-secrets"
+     ```
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
          ```yaml

--- a/docs/AzureMarketplaceGuide.md
+++ b/docs/AzureMarketplaceGuide.md
@@ -33,10 +33,10 @@ Note that **Company** is not required, but please enter it.
    You need several container images to run Scalar products on Kubernetes, but Azure Marketplace copies only one container image at a time. So, you need to subscribe to several software plans (repeat subscribe operation) as needed.
    * Container images that you need are the following.
         * ScalarDB
+            * ScalarDB Cluster (BYOL)
             * [Deprecated] ScalarDB Server Default (2vCPU, 4GiB Memory)
             * [Deprecated] ScalarDB GraphQL Server (optional)
             * [Deprecated] ScalarDB SQL Server (optional)
-            * [Recommended / coming soon] ScalarDB Cluster
         * ScalarDL
             * ScalarDL Ledger Default (2vCPU, 4GiB Memory)
             * ScalarDL Auditor Default (2vCPU, 4GiB Memory)
@@ -56,18 +56,12 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
    You need to specify your private container registry as the value of `[].image.repository` in the custom values file.  
-   * ScalarDB Examples
-      * [Deprecated] ScalarDB Server (scalardb-custom-values.yaml)
-        ```yaml
-        scalardb:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardb-server"
-        ```
-      * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
-        ```yaml
-        image:
-          repository: "example.azurecr.io/scalarinc/scalardb-graphql"
-        ```
+   * ScalarDB Cluster Examples
+     ```yaml
+     scalardbCluster:
+       image:
+         repository: "example.azurecr.io/scalarinc/scalardb-cluster-node-azure-byol"
+     ```
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml
@@ -89,15 +83,10 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         ```
 
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
-   * ScalarDB Examples
-      * [Deprecated] ScalarDB Server
-        ```console
-        helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
-        ```
-      * [Deprecated] ScalarDB GraphQL Server
-        ```console
-        helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
-        ```
+   * ScalarDB Cluster Examples
+     ```console
+     helm install scalardb-cluster scalar-labs/scalardb-cluster -f scalardb-cluster-custom-values.yaml
+     ```
    * ScalarDL Examples
       * ScalarDL Ledger
         ```console
@@ -135,22 +124,14 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Update the custom values file of the Helm Chart of a Scalar product you want to install.  
    You need to specify your private container registry as the value of `[].image.repository` in the custom values file.  
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
-   * ScalarDB Examples
-      * [Deprecated]  (scalardb-custom-values.yaml)
-        ```yaml
-        scalardb:
-          image:
-            repository: "example.azurecr.io/scalarinc/scalardb-server"
-          imagePullSecrets:
-            - name: "reg-acr-secrets"
-        ```
-      * [Deprecated] ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
-        ```yaml
-        image:
-          repository: "example.azurecr.io/scalarinc/scalardb-graphql"
-        imagePullSecrets:
-          - name: "reg-acr-secrets"
-        ```
+   * ScalarDB Cluster Examples
+     ```yaml
+     scalardbCluster:
+       image:
+         repository: "example.azurecr.io/scalarinc/scalardb-cluster-node-azure-byol"
+       imagePullSecrets:
+         - name: "reg-acr-secrets"
+     ```
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
         ```yaml


### PR DESCRIPTION
## Description

Now, we start providing `ScalarDB Cluster (BYOL)` in AWS/Azure Marketplace.

* [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-alcwrmw6v4cfy) (Note: It is still in progress. Not published yet.)
* [Azure Marketplace](https://azuremarketplace.microsoft.com/ja-jp/marketplace/apps/scalarinc.scalardb?tab=PlansAndPrice) (Note: We already published.)

So, I updated each Marketplace Guide.

## Related issues and/or PRs

N/A

## Changes made

* Added sample configurations and commands when we use ScalarDB Cluster.
* Marked ScalarDB Server as `Deprecated` and removed sample configurations and commands about ScalarDB Server.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Some documents still have descriptions of `ScalarDB Server`. So, I will mark `ScalarDB Server` as `Deprecated` in all documents in another PR.

