### PR TITLE
Update notice about the relocation of docs

### DIFF
--- a/docs/AccessScalarProducts.md
+++ b/docs/AccessScalarProducts.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/AwsMarketplaceGuide.md
+++ b/docs/AwsMarketplaceGuide.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/AzureMarketplaceGuide.md
+++ b/docs/AzureMarketplaceGuide.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/BackupNoSQL.md
+++ b/docs/BackupNoSQL.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/BackupRDB.md
+++ b/docs/BackupRDB.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/BackupRestoreGuide.md
+++ b/docs/BackupRestoreGuide.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateAKSClusterForScalarDB.md
+++ b/docs/CreateAKSClusterForScalarDB.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateAKSClusterForScalarDL.md
+++ b/docs/CreateAKSClusterForScalarDL.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/CreateAKSClusterForScalarDLAuditor.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateAKSClusterForScalarProducts.md
+++ b/docs/CreateAKSClusterForScalarProducts.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateBastionServer.md
+++ b/docs/CreateBastionServer.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateEKSClusterForScalarDB.md
+++ b/docs/CreateEKSClusterForScalarDB.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateEKSClusterForScalarDBCluster.md
+++ b/docs/CreateEKSClusterForScalarDBCluster.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateEKSClusterForScalarDL.md
+++ b/docs/CreateEKSClusterForScalarDL.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/CreateEKSClusterForScalarDLAuditor.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/CreateEKSClusterForScalarProducts.md
+++ b/docs/CreateEKSClusterForScalarProducts.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/K8sLogCollectionGuide.md
+++ b/docs/K8sLogCollectionGuide.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/K8sMonitorGuide.md
+++ b/docs/K8sMonitorGuide.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ManualDeploymentGuideScalarDBClusterOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDBClusterOnEKS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDBServerOnEKS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnAKS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLAuditorOnEKS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ManualDeploymentGuideScalarDLOnAKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnAKS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ManualDeploymentGuideScalarDLOnEKS.md
+++ b/docs/ManualDeploymentGuideScalarDLOnEKS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/NetworkPeeringForScalarDLAuditor.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ProductionChecklistForScalarDBCluster.md
+++ b/docs/ProductionChecklistForScalarDBCluster.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ProductionChecklistForScalarDLAuditor.md
+++ b/docs/ProductionChecklistForScalarDLAuditor.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ProductionChecklistForScalarDLLedger.md
+++ b/docs/ProductionChecklistForScalarDLLedger.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/ProductionChecklistForScalarProducts.md
+++ b/docs/ProductionChecklistForScalarProducts.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/RegularCheck.md
+++ b/docs/RegularCheck.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/RestoreDatabase.md
+++ b/docs/RestoreDatabase.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/SetupDatabase.md
+++ b/docs/SetupDatabase.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/SetupDatabaseForAWS.md
+++ b/docs/SetupDatabaseForAWS.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/SetupDatabaseForAzure.md
+++ b/docs/SetupDatabaseForAzure.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/alerts/Envoy.md
+++ b/docs/alerts/Envoy.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/alerts/Ledger.md
+++ b/docs/alerts/Ledger.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 

--- a/docs/alerts/README.md
+++ b/docs/alerts/README.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> The contents of the `docs` folder have been moved to the [docs-internal-orchestration](https://github.com/scalar-labs/docs-internal-orchestration) repository. Please update this documentation in that repository instead.
 > 
 > To view the Scalar Kubernetes documentation, visit the documentation site for the product you are using:
 > 


### PR DESCRIPTION
## Description

This PR updates the notice about where the Scalar Kubernetes docs have been moved to. 

> [!NOTE]
>
> We had originally planned for them to be in a centralized repository with other docs. However, we realized that we needed to have docs in product-specific repositories that follow a version branch pattern in the same way that we release versions.

## Related issues and/or PRs

- **PR where I had originally added the notice:** https://github.com/scalar-labs/scalar-kubernetes/pull/217

## Changes made

- Updated the repository link and wording in the notice at the top of each doc.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
